### PR TITLE
debug: DASHBOARD FILE console.log in page.tsx + layout.tsx [Mar 26 2026]

### DIFF
--- a/app/dashboard/layout.tsx
+++ b/app/dashboard/layout.tsx
@@ -1,3 +1,5 @@
+// DEBUG — remove after identifying active file
+console.log('DASHBOARD FILE: app/dashboard/layout.tsx');
 import { Metadata } from "next";
 
 export const metadata: Metadata = {

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -6,6 +6,9 @@
 
 'use client';
 
+// DEBUG — remove after identifying active file
+console.log('DASHBOARD FILE: app/dashboard/page.tsx');
+
 import React, { useState, useEffect } from 'react';
 import Link from 'next/link';
 import { useAuth } from '@/app/providers';


### PR DESCRIPTION
Adds `console.log('DASHBOARD FILE: ...')` at the top of:

- `app/dashboard/page.tsx`
- `app/dashboard/layout.tsx`

Load `/dashboard` on the preview URL, then check Vercel runtime logs to see which one fires. Whichever logs is the active file serving `/dashboard`.

**Remove both logs and close this PR after the file is identified.**