### PR TITLE
fix: dashboard — Buy Credits + Upgrade Plan moved outside AccountColumn [Mar 26 2026]

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -253,25 +253,6 @@ function AccountColumn({ user, credits, plan, isAdmin }: {
         </div>
       </Card>
 
-      {/* ── Always-visible action row ────────────────────────────── */}
-      <div className="flex gap-3 mt-4">
-        <button
-          type="button"
-          onClick={handleBuyCredits}
-          disabled={buyLoading}
-          className="flex-1 bg-blue-600 hover:bg-blue-700 disabled:bg-blue-400 text-white px-4 py-2 rounded-md text-sm font-semibold transition-colors disabled:cursor-wait"
-        >
-          {buyLoading ? 'Redirecting...' : 'Buy Credits'}
-        </button>
-        <button
-          type="button"
-          onClick={() => window.location.href = '/pricing'}
-          className="flex-1 bg-black hover:bg-gray-800 text-white px-4 py-2 rounded-md text-sm font-semibold transition-colors"
-        >
-          Upgrade Plan
-        </button>
-      </div>
-
       {/* ── Billing ──────────────────────────────────────────────── */}
       <Card>
         <SectionTitle>Billing</SectionTitle>
@@ -413,6 +394,24 @@ export default function DashboardPage() {
                 plan={plan}
                 isAdmin={isAdmin}
               />
+            </div>
+
+            {/* ── Action buttons — outside AccountColumn, no conditionals ── */}
+            <div className="flex gap-3 mt-4 lg:col-span-1">
+              <button
+                type="button"
+                onClick={handleBuyCredits}
+                className="flex-1 bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-md text-sm font-semibold"
+              >
+                Buy Credits
+              </button>
+              <button
+                type="button"
+                onClick={() => window.location.href='/pricing'}
+                className="flex-1 bg-black hover:bg-gray-800 text-white px-4 py-2 rounded-md text-sm font-semibold"
+              >
+                Upgrade Plan
+              </button>
             </div>
 
             {/* Right column: apps + CTA */}


### PR DESCRIPTION
Two surgical patches to `app/dashboard/page.tsx`.

**Patch 1 — Remove:** Deleted the `flex gap-3 mt-4` button row that was previously inserted inside `AccountColumn` (between Credits card and Billing card). That location is inside the component, wrapped by the `{user ? ...}` conditional.

**Patch 2 — Insert:** Added a new `<div className='flex gap-3 mt-4 lg:col-span-1'>` row directly in `DashboardPage`'s grid, between the left column (`AccountColumn`) and the right column (Quick Access + Activity). This is inside the same parent container as the Credits card's column but **not inside `AccountColumn`** and **not inside any conditional** beyond the outer `{user ? ...}` block that gates the entire logged-in layout.

**Both buttons:**
- Buy Credits → `onClick={handleBuyCredits}` (calls `/api/billing/checkout`)
- Upgrade Plan → `onClick={() => window.location.href='/pricing'}`

No Stripe logic, vault logic, or API calls modified. `handleBuyCredits` function in `AccountColumn` is untouched.

**DO NOT MERGE without Roy's approval.**