### PR TITLE
debug: Stripe e2e logs — CHECKOUT SESSION CREATED, WEBHOOK RECEIVED, CREDITS UPDATED [Mar 26 2026]

### DIFF
--- a/app/api/billing/checkout/route.ts
+++ b/app/api/billing/checkout/route.ts
@@ -107,6 +107,13 @@ export async function POST(req: NextRequest) {
         subscription_data: { metadata: { userId } },
         allow_promotion_codes: true,
       })
+      console.log('CHECKOUT SESSION CREATED', {
+        mode:      'subscription',
+        userId,
+        priceId,
+        sessionId: session.id,
+        url:       session.url?.slice(0, 60) + '...',
+      })
       return NextResponse.json({ url: session.url, sessionId: session.id })
     }
 
@@ -139,6 +146,14 @@ export async function POST(req: NextRequest) {
             price_id:        priceId,
           },
         },
+      })
+      console.log('CHECKOUT SESSION CREATED', {
+        mode:           'payment',
+        userId,
+        priceId,
+        creditsGranted: PACK_CREDITS[priceId],
+        sessionId:      session.id,
+        url:            session.url?.slice(0, 60) + '...',
       })
       return NextResponse.json({ url: session.url, sessionId: session.id })
     }

--- a/app/api/billing/webhook/route.ts
+++ b/app/api/billing/webhook/route.ts
@@ -152,6 +152,11 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: 'Invalid signature' }, { status: 400 })
   }
 
+  console.log('WEBHOOK RECEIVED', {
+    type:    event.type,
+    eventId: event.id.slice(0, 20) + '...',
+  })
+
   // ── Idempotency guard ──────────────────────────────────────────────────────
   const { data: existing } = await supabase
     .from('billing_events')
@@ -197,6 +202,13 @@ export async function POST(req: NextRequest) {
           }
 
           await grantCreditsToLedger(supabase, userId, credits, 'stripe_pack', priceId, event.id)
+          console.log('CREDITS UPDATED', {
+            source:  'stripe_pack',
+            userId:  userId.slice(0, 8) + '…',
+            credits,
+            priceId,
+            eventId: event.id.slice(0, 20) + '...',
+          })
           break
         }
 
@@ -212,6 +224,13 @@ export async function POST(req: NextRequest) {
 
         if (credits > 0) {
           await grantCreditsToLedger(supabase, userId, credits, 'stripe_subscription', subPriceId, event.id)
+          console.log('CREDITS UPDATED', {
+            source:    'stripe_subscription',
+            userId:    userId.slice(0, 8) + '…',
+            credits,
+            subPriceId,
+            eventId:   event.id.slice(0, 20) + '...',
+          })
         } else if (session.mode === 'subscription') {
           console.warn('[billing/webhook] subscription checkout — no credit grant for priceId:', subPriceId)
         }


### PR DESCRIPTION
Adds 5 temporary structured `console.log` statements across both live billing routes.

**`app/api/billing/checkout/route.ts`:**
- `CHECKOUT SESSION CREATED` × 2 (subscription + payment modes)
  — logs `mode, userId, priceId, [creditsGranted], sessionId, url prefix`

**`app/api/billing/webhook/route.ts`:**
- `WEBHOOK RECEIVED` after signature verification — logs `type, eventId`
- `CREDITS UPDATED` × 2 (stripe_pack + stripe_subscription)
  — logs `source, userId (masked), credits, priceId/subPriceId, eventId`

**Routes targeted:** `app/api/billing/` (vault-wired, active). NOT the legacy `app/api/stripe/` routes.

No business logic, vault logic, or signatures modified. Preview only — no production deploy.

**Remove these logs and close PR after flow verified.**