### PR TITLE
feat: Stripe hard-lock final — cleanHost, safety guard, no VERCEL_ENV [Apr 9 2026]

### DIFF
--- a/app/api/billing/checkout/route.ts
+++ b/app/api/billing/checkout/route.ts
@@ -14,16 +14,23 @@ import { getSecret } from '@/lib/vault/getSecret'
 export const dynamic = 'force-dynamic'
 export const runtime = 'nodejs'
 
-async function stripe(): Promise<Stripe> {
-  const isProd   = process.env.VERCEL_ENV === 'production'
-  const vaultKey = isProd ? 'STRIPE_SECRET_KEY_LIVE' : 'STRIPE_SECRET_KEY_TEST'
+async function stripe(req: NextRequest): Promise<Stripe> {
+  const host      = req.headers.get('host') || ''
+  const cleanHost = host.split(':')[0]
+  const isProd    = cleanHost === 'craudiovizai.com' || cleanHost === 'www.craudiovizai.com'
+  const vaultKey  = isProd ? 'STRIPE_SECRET_KEY_LIVE' : 'STRIPE_SECRET_KEY_TEST'
+
+  // Safety guard — hard crash if non-prod host ever resolves to LIVE key
+  if (!isProd && vaultKey === 'STRIPE_SECRET_KEY_LIVE') {
+    throw new Error('🚨 SAFETY VIOLATION: Preview attempting to use LIVE Stripe key')
+  }
 
   const STRIPE_SECRET_KEY = await getSecret(vaultKey).catch(() => null)
   if (!STRIPE_SECRET_KEY) {
-    throw new Error(`Stripe key missing for environment: ${vaultKey}`)
+    throw new Error(`Stripe key missing for ${vaultKey}`)
   }
 
-  console.log('STRIPE_MODE', { env: process.env.VERCEL_ENV ?? 'local', vaultKey, isProd })
+  console.log('STRIPE HARD LOCK', { host, cleanHost, isProd, vaultKey })
 
   return new Stripe(STRIPE_SECRET_KEY, { apiVersion: '2024-06-20' })
 }
@@ -69,7 +76,7 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: 'priceId, userId, and email are required' }, { status: 400 })
     }
 
-    const s        = await stripe()
+    const s        = await stripe(req)
     const supabase = db()
     const baseUrl  = process.env.NEXT_PUBLIC_APP_URL ?? 'https://craudiovizai.com'
 

--- a/app/api/billing/webhook/route.ts
+++ b/app/api/billing/webhook/route.ts
@@ -26,16 +26,23 @@ import { getSecret } from '@/lib/vault/getSecret'
 export const dynamic = 'force-dynamic'
 export const runtime = 'nodejs'
 
-async function stripe(): Promise<Stripe> {
-  const isProd   = process.env.VERCEL_ENV === 'production'
-  const vaultKey = isProd ? 'STRIPE_SECRET_KEY_LIVE' : 'STRIPE_SECRET_KEY_TEST'
+async function stripe(req: NextRequest): Promise<Stripe> {
+  const host      = req.headers.get('host') || ''
+  const cleanHost = host.split(':')[0]
+  const isProd    = cleanHost === 'craudiovizai.com' || cleanHost === 'www.craudiovizai.com'
+  const vaultKey  = isProd ? 'STRIPE_SECRET_KEY_LIVE' : 'STRIPE_SECRET_KEY_TEST'
+
+  // Safety guard — hard crash if non-prod host ever resolves to LIVE key
+  if (!isProd && vaultKey === 'STRIPE_SECRET_KEY_LIVE') {
+    throw new Error('🚨 SAFETY VIOLATION: Preview attempting to use LIVE Stripe key')
+  }
 
   const STRIPE_SECRET_KEY = await getSecret(vaultKey).catch(() => null)
   if (!STRIPE_SECRET_KEY) {
-    throw new Error(`Stripe key missing for environment: ${vaultKey}`)
+    throw new Error(`Stripe key missing for ${vaultKey}`)
   }
 
-  console.log('STRIPE_MODE', { env: process.env.VERCEL_ENV ?? 'local', vaultKey, isProd })
+  console.log('STRIPE HARD LOCK', { host, cleanHost, isProd, vaultKey })
 
   return new Stripe(STRIPE_SECRET_KEY, { apiVersion: '2024-06-20' })
 }
@@ -133,7 +140,7 @@ async function grantCreditsToLedger(
 // ── Webhook POST handler ──────────────────────────────────────────────────────
 export async function POST(req: NextRequest) {
   const supabase = db()
-  const s        = await stripe()
+  const s        = await stripe(req)
 
   const payload   = await req.text()
   const signature = req.headers.get('stripe-signature') ?? ''


### PR DESCRIPTION
Applies the complete final Stripe environment lock to both billing routes. The squash merge of PR #71 captured an earlier version — this PR brings main to the fully hardened state.

**`stripe(req)` factory — both files:**
```typescript
async function stripe(req: NextRequest): Promise<Stripe> {
  const host      = req.headers.get('host') || ''
  const cleanHost = host.split(':')[0]           // strip port
  const isProd    = cleanHost === 'craudiovizai.com'
               || cleanHost === 'www.craudiovizai.com'
  const vaultKey  = isProd ? 'STRIPE_SECRET_KEY_LIVE' : 'STRIPE_SECRET_KEY_TEST'

  // Safety guard — hard crash if logic ever produces wrong combination
  if (!isProd && vaultKey === 'STRIPE_SECRET_KEY_LIVE') {
    throw new Error('🚨 SAFETY VIOLATION: Preview attempting to use LIVE Stripe key')
  }

  const STRIPE_SECRET_KEY = await getSecret(vaultKey).catch(() => null)
  if (!STRIPE_SECRET_KEY) throw new Error(`Stripe key missing for ${vaultKey}`)

  console.log('STRIPE HARD LOCK', { host, cleanHost, isProd, vaultKey })
  return new Stripe(STRIPE_SECRET_KEY, { apiVersion: '2024-06-20' })
}
```

**Guarantees:**
- No `VERCEL_ENV` — domain name is the only source of truth
- No `process.env.STRIPE_SECRET_KEY` fallback
- Safety guard throws before vault is even called if `isProd` is false but vaultKey is LIVE
- `cleanHost` strips port for local dev safety
- `STRIPE HARD LOCK` log on every call shows host + key used

**DO NOT MERGE without Roy's approval.**