### PR TITLE
Debug: Stripe runtime host trace

### DIFF
--- a/app/api/billing/checkout/route.ts
+++ b/app/api/billing/checkout/route.ts
@@ -54,6 +54,12 @@ const PACK_CREDITS: Record<string, number> = {
 }
 
 export async function POST(req: NextRequest) {
+  console.log('STRIPE ENTRY', {
+    host:    req.headers.get('host'),
+    url:     req.url,
+    origin:  req.headers.get('origin'),
+    referer: req.headers.get('referer'),
+  })
   try {
     const body = await req.json()
     const {

--- a/app/api/billing/webhook/route.ts
+++ b/app/api/billing/webhook/route.ts
@@ -139,6 +139,12 @@ async function grantCreditsToLedger(
 
 // ── Webhook POST handler ──────────────────────────────────────────────────────
 export async function POST(req: NextRequest) {
+  console.log('STRIPE ENTRY', {
+    host:    req.headers.get('host'),
+    url:     req.url,
+    origin:  req.headers.get('origin'),
+    referer: req.headers.get('referer'),
+  })
   const supabase = db()
   const s        = await stripe(req)
 


### PR DESCRIPTION
Adds `STRIPE ENTRY` log at the very top of both POST handlers.

```typescript
console.log('STRIPE ENTRY', {
  host:    req.headers.get('host'),
  url:     req.url,
  origin:  req.headers.get('origin'),
  referer: req.headers.get('referer'),
})
```

Fires before any logic, before `stripe(req)` is called. Shows exact host, URL, origin, and referer on every request to either route.

No logic changes. No refactoring. Logging only.

**Remove after host trace is confirmed. DO NOT MERGE without Roy's approval.**