### PR TITLE
fix: dynamic CORS for billing routes — remove static CORS from vercel.json + next.config [Apr 9 2026]

### DIFF
--- a/app/api/billing/checkout/route.ts
+++ b/app/api/billing/checkout/route.ts
@@ -35,6 +35,23 @@ async function stripe(req: NextRequest): Promise<Stripe> {
   return new Stripe(STRIPE_SECRET_KEY, { apiVersion: '2024-06-20' })
 }
 
+
+// ── Dynamic CORS — reflect origin if it's craudiovizai.com or any vercel.app ─
+function getCorsHeaders(req: NextRequest): Record<string, string> {
+  const origin  = req.headers.get('origin') || ''
+  const allowed = origin.includes('craudiovizai.com') || origin.includes('.vercel.app')
+  return {
+    'Access-Control-Allow-Origin':      allowed ? origin : '',
+    'Access-Control-Allow-Credentials': 'true',
+    'Access-Control-Allow-Methods':     'POST, GET, OPTIONS',
+    'Access-Control-Allow-Headers':     'Content-Type, Authorization',
+  }
+}
+
+export async function OPTIONS(req: NextRequest) {
+  return new Response(null, { status: 200, headers: getCorsHeaders(req) })
+}
+
 function db() {
   return createClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!)
 }
@@ -54,6 +71,7 @@ const PACK_CREDITS: Record<string, number> = {
 }
 
 export async function POST(req: NextRequest) {
+  const corsHeaders = getCorsHeaders(req)
   try {
     const body = await req.json()
     const {
@@ -73,7 +91,7 @@ export async function POST(req: NextRequest) {
     }
 
     if (!priceId || !userId || !email) {
-      return NextResponse.json({ error: 'priceId, userId, and email are required' }, { status: 400 })
+      return NextResponse.json({ error: 'priceId, userId, and email are required' }, { status: 400, headers: corsHeaders })
     }
 
     const s        = await stripe(req)
@@ -127,7 +145,7 @@ export async function POST(req: NextRequest) {
         sessionId: session.id,
         url:       session.url?.slice(0, 60) + '...',
       })
-      return NextResponse.json({ url: session.url, sessionId: session.id })
+      return NextResponse.json({ url: session.url, sessionId: session.id }, { headers: corsHeaders })
     }
 
     // ── Payment mode — one-time credit pack purchase ───────────────────────────
@@ -136,7 +154,7 @@ export async function POST(req: NextRequest) {
       if (!creditsGranted) {
         return NextResponse.json(
           { error: `Unknown credit pack priceId: ${priceId}` },
-          { status: 400 }
+          { status: 400, headers: corsHeaders }
         )
       }
 
@@ -168,14 +186,14 @@ export async function POST(req: NextRequest) {
         sessionId:      session.id,
         url:            session.url?.slice(0, 60) + '...',
       })
-      return NextResponse.json({ url: session.url, sessionId: session.id })
+      return NextResponse.json({ url: session.url, sessionId: session.id }, { headers: corsHeaders })
     }
 
-    return NextResponse.json({ error: `Unknown mode: ${mode}` }, { status: 400 })
+    return NextResponse.json({ error: `Unknown mode: ${mode}` }, { status: 400, headers: corsHeaders })
 
   } catch (err: unknown) {
     const msg = err instanceof Error ? err.message : String(err)
     console.error('[billing/checkout] error:', msg)
-    return NextResponse.json({ error: msg }, { status: 500 })
+    return NextResponse.json({ error: msg }, { status: 500, headers: corsHeaders })
   }
 }

--- a/app/api/billing/webhook/route.ts
+++ b/app/api/billing/webhook/route.ts
@@ -47,6 +47,23 @@ async function stripe(req: NextRequest): Promise<Stripe> {
   return new Stripe(STRIPE_SECRET_KEY, { apiVersion: '2024-06-20' })
 }
 
+
+// ── Dynamic CORS — reflect origin if it's craudiovizai.com or any vercel.app ─
+function getCorsHeaders(req: NextRequest): Record<string, string> {
+  const origin  = req.headers.get('origin') || ''
+  const allowed = origin.includes('craudiovizai.com') || origin.includes('.vercel.app')
+  return {
+    'Access-Control-Allow-Origin':      allowed ? origin : '',
+    'Access-Control-Allow-Credentials': 'true',
+    'Access-Control-Allow-Methods':     'POST, GET, OPTIONS',
+    'Access-Control-Allow-Headers':     'Content-Type, Authorization',
+  }
+}
+
+export async function OPTIONS(req: NextRequest) {
+  return new Response(null, { status: 200, headers: getCorsHeaders(req) })
+}
+
 function db() {
   return createClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
@@ -139,6 +156,7 @@ async function grantCreditsToLedger(
 
 // ── Webhook POST handler ──────────────────────────────────────────────────────
 export async function POST(req: NextRequest) {
+  const corsHeaders = getCorsHeaders(req)
   const supabase = db()
   const s        = await stripe(req)
 
@@ -152,7 +170,7 @@ export async function POST(req: NextRequest) {
 
   if (!secret) {
     console.error('[billing/webhook] STRIPE_WEBHOOK_SECRET not configured')
-    return NextResponse.json({ error: 'Webhook secret not configured' }, { status: 500 })
+    return NextResponse.json({ error: 'Webhook secret not configured' }, { status: 500, headers: corsHeaders })
   }
 
   // ── Signature verification ─────────────────────────────────────────────────
@@ -162,7 +180,7 @@ export async function POST(req: NextRequest) {
   } catch (err: unknown) {
     const msg = err instanceof Error ? err.message : String(err)
     console.error('[billing/webhook] signature failed:', msg)
-    return NextResponse.json({ error: 'Invalid signature' }, { status: 400 })
+    return NextResponse.json({ error: 'Invalid signature' }, { status: 400, headers: corsHeaders })
   }
 
   console.log('WEBHOOK RECEIVED', {
@@ -180,7 +198,7 @@ export async function POST(req: NextRequest) {
 
   if (existing) {
     console.log(`[billing/webhook] duplicate skipped: ${event.id}`)
-    return NextResponse.json({ received: true, skipped: 'duplicate' })
+    return NextResponse.json({ received: true, skipped: 'duplicate' }, { headers: corsHeaders })
   }
 
   // ── Log raw event ─────────────────────────────────────────────────────────
@@ -286,11 +304,11 @@ export async function POST(req: NextRequest) {
       .update({ processed: true })
       .eq('stripe_event_id', event.id)
 
-    return NextResponse.json({ received: true, type: event.type })
+    return NextResponse.json({ received: true, type: event.type }, { headers: corsHeaders })
 
   } catch (err: unknown) {
     const msg = err instanceof Error ? err.message : String(err)
     console.error('[billing/webhook] handler error:', { type: event.type, msg })
-    return NextResponse.json({ error: msg }, { status: 500 })
+    return NextResponse.json({ error: msg }, { status: 500, headers: corsHeaders })
   }
 }

--- a/next.config.js
+++ b/next.config.js
@@ -38,76 +38,19 @@ const nextConfig = {
       bodySizeLimit: '2mb',
     },
   },
-  // Security + CORS Headers
-  // 2026-02-20 — Expanded CORS: all javari-*.vercel.app preview URLs + production
+  // Security headers — CORS handled dynamically per-route in API handlers
+  // 2026-04-09 — Removed static CORS from next.config: billing routes now use
+  // dynamic origin reflection (see app/api/billing/*/route.ts).
   async headers() {
-    // NOTE: Access-Control-Allow-Origin cannot use wildcards with credentials.
-    // We use the production domain here; dynamic preview URL matching is handled
-    // per-route via the X-Internal-Secret bypass (see /api/internal/ping).
-    // All javari-ai serverless calls carry X-Internal-Request + X-Internal-Secret.
-    const ALLOWED_JAVARI_ORIGINS = [
-      'https://javariai.com',
-      'https://www.javariai.com',
-      // Static preview alias (updated when javari-ai gets a stable alias)
-      'https://javari-ai.vercel.app',
-    ].join(', ');
-
     return [
-      // ── CORS preflight for all /api/* routes ──────────────────────────
-      {
-        source: '/api/:path*',
-        headers: [
-          {
-            key: 'Access-Control-Allow-Origin',
-            value: ALLOWED_JAVARI_ORIGINS,
-          },
-          {
-            key: 'Access-Control-Allow-Methods',
-            value: 'GET, POST, PUT, PATCH, DELETE, OPTIONS',
-          },
-          {
-            key: 'Access-Control-Allow-Headers',
-            value: [
-              'Content-Type',
-              'Authorization',
-              'X-Internal-Request',
-              'X-Internal-Secret',
-              'X-Request-Source',
-              'X-User-Id',
-              'X-App-Id',
-              'X-Javari-Key',
-            ].join(', '),
-          },
-          {
-            key: 'Access-Control-Max-Age',
-            value: '86400', // 24hr preflight cache
-          },
-        ],
-      },
-      // ── Security headers for all other routes ─────────────────────────
       {
         source: '/(.*)',
         headers: [
-          {
-            key: 'X-Content-Type-Options',
-            value: 'nosniff',
-          },
-          {
-            key: 'X-Frame-Options',
-            value: 'DENY',
-          },
-          {
-            key: 'X-XSS-Protection',
-            value: '1; mode=block',
-          },
-          {
-            key: 'Referrer-Policy',
-            value: 'strict-origin-when-cross-origin',
-          },
-          {
-            key: 'Permissions-Policy',
-            value: 'camera=(), microphone=(), geolocation=()',
-          },
+          { key: 'X-Content-Type-Options', value: 'nosniff' },
+          { key: 'X-Frame-Options',        value: 'DENY' },
+          { key: 'X-XSS-Protection',       value: '1; mode=block' },
+          { key: 'Referrer-Policy',         value: 'strict-origin-when-cross-origin' },
+          { key: 'Permissions-Policy',      value: 'camera=(), microphone=(), geolocation=()' },
           {
             key: 'Content-Security-Policy',
             value: "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdnjs.cloudflare.com https://js.stripe.com https://www.paypal.com https://www.google-analytics.com https://www.googletagmanager.com https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com data:; img-src 'self' data: blob: https: http:; connect-src 'self' https://*.supabase.co https://api.stripe.com https://api.paypal.com https://api.openai.com https://api.anthropic.com https://generativelanguage.googleapis.com https://cloudflareinsights.com wss://*.supabase.co; frame-src https://js.stripe.com https://www.paypal.com https://www.youtube.com; object-src 'none'; base-uri 'self';",

--- a/vercel.json
+++ b/vercel.json
@@ -46,27 +46,6 @@
           "value": "connect-src 'self' https://javari-ai.vercel.app https://*.supabase.co https://*.vercel.app https://api.resend.com https://api.stripe.com https://www.paypal.com; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdnjs.cloudflare.com https://js.stripe.com https://www.paypal.com https://www.google-analytics.com https://www.googletagmanager.com https://static.cloudflareinsights.com; img-src 'self' data: https://*; frame-src 'self' https://javariai.com https://javari-ai.vercel.app https://js.stripe.com https://www.paypal.com; default-src 'self';"
         }
       ]
-    },
-    {
-      "source": "/api/(.*)",
-      "headers": [
-        {
-          "key": "Access-Control-Allow-Origin",
-          "value": "https://javariai.com, https://javari-ai.vercel.app"
-        },
-        {
-          "key": "Access-Control-Allow-Methods",
-          "value": "GET, POST, PUT, PATCH, DELETE, OPTIONS"
-        },
-        {
-          "key": "Access-Control-Allow-Headers",
-          "value": "Content-Type, Authorization, X-Internal-Request, X-Internal-Secret, X-User-Id, X-Request-Source"
-        },
-        {
-          "key": "Access-Control-Max-Age",
-          "value": "86400"
-        }
-      ]
     }
   ],
   "github": {


### PR DESCRIPTION
Fixes the CORS block causing 500s on preview checkout.

**Root cause:** `vercel.json` and `next.config.js` both set static `Access-Control-Allow-Origin: https://javariai.com, https://javari-ai.vercel.app`. Preview deployments on `craudiovizai-*.vercel.app` were rejected by the browser before the request reached Stripe.

**Files changed (4):**

**`vercel.json`** — removed entire `/api/(.*)` CORS header block. Security headers on `/(.*)`retained untouched.

**`next.config.js`** — removed `ALLOWED_JAVARI_ORIGINS` and the `/api/:path*` CORS header block. Security headers retained.

**`app/api/billing/checkout/route.ts`** — added `getCorsHeaders(req)` helper and `OPTIONS` preflight handler. `corsHeaders` attached to all responses.

**`app/api/billing/webhook/route.ts`** — same `getCorsHeaders` + `OPTIONS` + all responses carry `corsHeaders`.

**CORS logic:**
```typescript
const origin  = req.headers.get('origin') || ''
const allowed = origin.includes('craudiovizai.com') || origin.includes('.vercel.app')
// Reflects origin back if allowed — required for credentials: true
// No wildcard used — satisfies browsers with withCredentials
```

No Stripe logic, vault logic, or business logic modified.

**DO NOT MERGE without Roy's approval.**