### PR TITLE
feat: Stripe VERCEL_ENV vault selector — remove host-based logic [Apr 9 2026]

### DIFF
--- a/app/api/billing/checkout/route.ts
+++ b/app/api/billing/checkout/route.ts
@@ -14,24 +14,17 @@ import { getSecret } from '@/lib/vault/getSecret'
 export const dynamic = 'force-dynamic'
 export const runtime = 'nodejs'
 
-async function stripe(req: NextRequest): Promise<Stripe> {
-  const host      = req.headers.get('host') || ''
-  const cleanHost = host.split(':')[0]
-  const isProd    = cleanHost === 'craudiovizai.com' || cleanHost === 'www.craudiovizai.com'
-  const vaultKey  = isProd ? 'STRIPE_SECRET_KEY_LIVE' : 'STRIPE_SECRET_KEY_TEST'
-
-  // Safety guard — hard crash if non-prod host ever resolves to LIVE key
-  if (!isProd && vaultKey === 'STRIPE_SECRET_KEY_LIVE') {
-    throw new Error('🚨 SAFETY VIOLATION: Preview attempting to use LIVE Stripe key')
-  }
-
+async function stripe(): Promise<Stripe> {
+  const env      = process.env.VERCEL_ENV || 'development'
+  const vaultKey =
+    env === 'production'
+      ? 'STRIPE_SECRET_KEY_LIVE'
+      : 'STRIPE_SECRET_KEY_TEST'
   const STRIPE_SECRET_KEY = await getSecret(vaultKey).catch(() => null)
   if (!STRIPE_SECRET_KEY) {
     throw new Error(`Stripe key missing for ${vaultKey}`)
   }
-
-  console.log('STRIPE HARD LOCK', { host, cleanHost, isProd, vaultKey })
-
+  console.log('STRIPE ENV ROUTING', { env, vaultKey })
   return new Stripe(STRIPE_SECRET_KEY, { apiVersion: '2024-06-20' })
 }
 
@@ -76,7 +69,7 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: 'priceId, userId, and email are required' }, { status: 400 })
     }
 
-    const s        = await stripe(req)
+    const s        = await stripe()
     const supabase = db()
     const baseUrl  = process.env.NEXT_PUBLIC_APP_URL ?? 'https://craudiovizai.com'
 

--- a/app/api/billing/webhook/route.ts
+++ b/app/api/billing/webhook/route.ts
@@ -26,24 +26,17 @@ import { getSecret } from '@/lib/vault/getSecret'
 export const dynamic = 'force-dynamic'
 export const runtime = 'nodejs'
 
-async function stripe(req: NextRequest): Promise<Stripe> {
-  const host      = req.headers.get('host') || ''
-  const cleanHost = host.split(':')[0]
-  const isProd    = cleanHost === 'craudiovizai.com' || cleanHost === 'www.craudiovizai.com'
-  const vaultKey  = isProd ? 'STRIPE_SECRET_KEY_LIVE' : 'STRIPE_SECRET_KEY_TEST'
-
-  // Safety guard — hard crash if non-prod host ever resolves to LIVE key
-  if (!isProd && vaultKey === 'STRIPE_SECRET_KEY_LIVE') {
-    throw new Error('🚨 SAFETY VIOLATION: Preview attempting to use LIVE Stripe key')
-  }
-
+async function stripe(): Promise<Stripe> {
+  const env      = process.env.VERCEL_ENV || 'development'
+  const vaultKey =
+    env === 'production'
+      ? 'STRIPE_SECRET_KEY_LIVE'
+      : 'STRIPE_SECRET_KEY_TEST'
   const STRIPE_SECRET_KEY = await getSecret(vaultKey).catch(() => null)
   if (!STRIPE_SECRET_KEY) {
     throw new Error(`Stripe key missing for ${vaultKey}`)
   }
-
-  console.log('STRIPE HARD LOCK', { host, cleanHost, isProd, vaultKey })
-
+  console.log('STRIPE ENV ROUTING', { env, vaultKey })
   return new Stripe(STRIPE_SECRET_KEY, { apiVersion: '2024-06-20' })
 }
 
@@ -140,7 +133,7 @@ async function grantCreditsToLedger(
 // ── Webhook POST handler ──────────────────────────────────────────────────────
 export async function POST(req: NextRequest) {
   const supabase = db()
-  const s        = await stripe(req)
+  const s        = await stripe()
 
   const payload   = await req.text()
   const signature = req.headers.get('stripe-signature') ?? ''


### PR DESCRIPTION
Replaces host-based `stripe(req)` factory with `VERCEL_ENV` vault selector.

**New `stripe()` — both files:**
```typescript
async function stripe(): Promise<Stripe> {
  const env      = process.env.VERCEL_ENV || 'development'
  const vaultKey = env === 'production'
    ? 'STRIPE_SECRET_KEY_LIVE'
    : 'STRIPE_SECRET_KEY_TEST'
  const STRIPE_SECRET_KEY = await getSecret(vaultKey).catch(() => null)
  if (!STRIPE_SECRET_KEY) throw new Error(`Stripe key missing for ${vaultKey}`)
  console.log('STRIPE ENV ROUTING', { env, vaultKey })
  return new Stripe(STRIPE_SECRET_KEY, { apiVersion: '2024-06-20' })
}
```

**Removed from factory:** `host`, `cleanHost`, `isProd`, domain equality checks, `STRIPE HARD LOCK` log, safety guard, `process.env.STRIPE_SECRET_KEY`, `req` param.

**Call sites:** `await stripe(req)` → `await stripe()` in both POST handlers.

**CORS fix** (PR #74) is on a separate branch and not affected.

**DO NOT MERGE without Roy's approval.**