### PR TITLE
Stripe final cleanup — env-based routing only

### DIFF
--- a/app/api/billing/checkout/route.ts
+++ b/app/api/billing/checkout/route.ts
@@ -1,7 +1,7 @@
 // app/api/billing/checkout/route.ts
 // Central billing authority — Stripe Checkout session creation.
 // Supports both subscription (plan upgrades) and payment (credit pack one-time) modes.
-// Updated: April 9, 2026 — process.env.STRIPE_SECRET_KEY direct, no vault routing.
+// Updated: April 9, 2026 — process.env.STRIPE_SECRET_KEY direct, env-split via Vercel.
 //
 // POST { priceId, userId, email, mode?, successUrl?, cancelUrl? }
 // mode: "subscription" (default) | "payment"

--- a/app/api/billing/checkout/route.ts
+++ b/app/api/billing/checkout/route.ts
@@ -1,7 +1,7 @@
 // app/api/billing/checkout/route.ts
 // Central billing authority — Stripe Checkout session creation.
 // Supports both subscription (plan upgrades) and payment (credit pack one-time) modes.
-// Updated: March 26, 2026 — vault-first STRIPE_SECRET_KEY via getSecret().
+// Updated: April 9, 2026 — process.env.STRIPE_SECRET_KEY direct, no vault routing.
 //
 // POST { priceId, userId, email, mode?, successUrl?, cancelUrl? }
 // mode: "subscription" (default) | "payment"
@@ -9,29 +9,15 @@
 import { NextRequest, NextResponse } from 'next/server'
 import Stripe from 'stripe'
 import { createClient } from '@supabase/supabase-js'
-import { getSecret } from '@/lib/vault/getSecret'
 
 export const dynamic = 'force-dynamic'
 export const runtime = 'nodejs'
 
-async function stripe(req: NextRequest): Promise<Stripe> {
-  const host      = req.headers.get('host') || ''
-  const cleanHost = host.split(':')[0]
-  const isProd    = cleanHost === 'craudiovizai.com' || cleanHost === 'www.craudiovizai.com'
-  const vaultKey  = isProd ? 'STRIPE_SECRET_KEY_LIVE' : 'STRIPE_SECRET_KEY_TEST'
-
-  // Safety guard — hard crash if non-prod host ever resolves to LIVE key
-  if (!isProd && vaultKey === 'STRIPE_SECRET_KEY_LIVE') {
-    throw new Error('🚨 SAFETY VIOLATION: Preview attempting to use LIVE Stripe key')
-  }
-
-  const STRIPE_SECRET_KEY = await getSecret(vaultKey).catch(() => null)
+async function stripe(): Promise<Stripe> {
+  const STRIPE_SECRET_KEY = process.env.STRIPE_SECRET_KEY
   if (!STRIPE_SECRET_KEY) {
-    throw new Error(`Stripe key missing for ${vaultKey}`)
+    throw new Error('Stripe key missing')
   }
-
-  console.log('STRIPE HARD LOCK', { host, cleanHost, isProd, vaultKey })
-
   return new Stripe(STRIPE_SECRET_KEY, { apiVersion: '2024-06-20' })
 }
 
@@ -76,7 +62,7 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: 'priceId, userId, and email are required' }, { status: 400 })
     }
 
-    const s        = await stripe(req)
+    const s        = await stripe()
     const supabase = db()
     const baseUrl  = process.env.NEXT_PUBLIC_APP_URL ?? 'https://craudiovizai.com'
 

--- a/app/api/billing/webhook/route.ts
+++ b/app/api/billing/webhook/route.ts
@@ -26,24 +26,11 @@ import { getSecret } from '@/lib/vault/getSecret'
 export const dynamic = 'force-dynamic'
 export const runtime = 'nodejs'
 
-async function stripe(req: NextRequest): Promise<Stripe> {
-  const host      = req.headers.get('host') || ''
-  const cleanHost = host.split(':')[0]
-  const isProd    = cleanHost === 'craudiovizai.com' || cleanHost === 'www.craudiovizai.com'
-  const vaultKey  = isProd ? 'STRIPE_SECRET_KEY_LIVE' : 'STRIPE_SECRET_KEY_TEST'
-
-  // Safety guard — hard crash if non-prod host ever resolves to LIVE key
-  if (!isProd && vaultKey === 'STRIPE_SECRET_KEY_LIVE') {
-    throw new Error('🚨 SAFETY VIOLATION: Preview attempting to use LIVE Stripe key')
-  }
-
-  const STRIPE_SECRET_KEY = await getSecret(vaultKey).catch(() => null)
+async function stripe(): Promise<Stripe> {
+  const STRIPE_SECRET_KEY = process.env.STRIPE_SECRET_KEY
   if (!STRIPE_SECRET_KEY) {
-    throw new Error(`Stripe key missing for ${vaultKey}`)
+    throw new Error('Stripe key missing')
   }
-
-  console.log('STRIPE HARD LOCK', { host, cleanHost, isProd, vaultKey })
-
   return new Stripe(STRIPE_SECRET_KEY, { apiVersion: '2024-06-20' })
 }
 
@@ -140,7 +127,7 @@ async function grantCreditsToLedger(
 // ── Webhook POST handler ──────────────────────────────────────────────────────
 export async function POST(req: NextRequest) {
   const supabase = db()
-  const s        = await stripe(req)
+  const s        = await stripe()
 
   const payload   = await req.text()
   const signature = req.headers.get('stripe-signature') ?? ''


### PR DESCRIPTION
Removes all vault, host-based, and environment-routing logic from Stripe key selection. `process.env.STRIPE_SECRET_KEY` is the sole key source.

**New `stripe()` factory — both files:**
```typescript
async function stripe(): Promise<Stripe> {
  const STRIPE_SECRET_KEY = process.env.STRIPE_SECRET_KEY
  if (!STRIPE_SECRET_KEY) {
    throw new Error('Stripe key missing')
  }
  return new Stripe(STRIPE_SECRET_KEY, { apiVersion: '2024-06-20' })
}
```

**Removed from both files:**
- `host`, `cleanHost`, `isProd`, domain equality checks
- `vaultKey`, `STRIPE_SECRET_KEY_LIVE`, `STRIPE_SECRET_KEY_TEST`
- `getSecret()` for Stripe key (import removed from checkout)
- `VERCEL_ENV` references
- `STRIPE HARD LOCK` log, safety guard / SAFETY VIOLATION
- `req` param from factory and call sites

**Untouched:**
- CORS logic (handled in PR #74)
- Business logic: prices, metadata, redirects, credit grants
- `getSecret('STRIPE_WEBHOOK_SECRET')` in webhook POST handler
- All existing logs: CHECKOUT SESSION CREATED, WEBHOOK RECEIVED, CREDITS UPDATED

**DO NOT MERGE without Roy's approval.**