### PR TITLE
fix: checkout baseUrl — dynamic from request host, no NEXT_PUBLIC_APP_URL [Apr 13 2026]

### DIFF
--- a/app/api/billing/checkout/route.ts
+++ b/app/api/billing/checkout/route.ts
@@ -78,7 +78,9 @@ export async function POST(req: NextRequest) {
 
     const s        = await stripe(req)
     const supabase = db()
-    const baseUrl  = process.env.NEXT_PUBLIC_APP_URL ?? 'https://craudiovizai.com'
+    const host      = req.headers.get('host') ?? 'craudiovizai.com'
+    const protocol  = process.env.NODE_ENV === 'production' ? 'https' : 'http'
+    const baseUrl   = `${protocol}://${host}`
 
     // ── Resolve or create Stripe customer ─────────────────────────────────────
     const { data: existingSub } = await supabase


### PR DESCRIPTION
Replaces the static `baseUrl` fallback in `app/api/billing/checkout/route.ts`.

**Before:**
```typescript
const baseUrl = process.env.NEXT_PUBLIC_APP_URL ?? 'https://craudiovizai.com'
```

**After:**
```typescript
const host     = req.headers.get('host') ?? 'craudiovizai.com'
const protocol = process.env.NODE_ENV === 'production' ? 'https' : 'http'
const baseUrl  = `${protocol}://${host}`
```

**Why:** When `successUrl`/`cancelUrl` are not provided by the caller, the fallback was always `craudiovizai.com` regardless of environment. A preview checkout would redirect back to production after payment. With the dynamic baseUrl, the redirect returns to whichever host made the request.

**`app/api/billing/webhook/route.ts`** — no change. Webhook has no baseUrl.

No Stripe key logic, no vault logic, no business logic modified.

**DO NOT MERGE without Roy's approval.**