### PR TITLE
fix: auth callback — dynamic baseUrl from request host [Apr 13 2026]

### DIFF
--- a/app/api/auth/callback/route.ts
+++ b/app/api/auth/callback/route.ts
@@ -23,7 +23,9 @@ export async function GET(request: NextRequest) {
   const requestUrl = new URL(request.url)
   const code       = requestUrl.searchParams.get('code')
   const redirectTo = requestUrl.searchParams.get('redirect_to') ?? '/dashboard'
-  const baseUrl    = process.env.NEXT_PUBLIC_APP_URL ?? 'https://craudiovizai.com'
+  const host      = request.headers.get('host') ?? 'craudiovizai.com'
+  const protocol  = process.env.NODE_ENV === 'production' ? 'https' : 'http'
+  const baseUrl   = `${protocol}://${host}`
 
   if (!code) {
     console.error('[auth/callback] no code in query params')


### PR DESCRIPTION
Fixes post-login redirect always going to `craudiovizai.com` regardless of origin.

**Before:**
```typescript
const baseUrl = process.env.NEXT_PUBLIC_APP_URL ?? 'https://craudiovizai.com'
```

**After:**
```typescript
const host     = request.headers.get('host') ?? 'craudiovizai.com'
const protocol = process.env.NODE_ENV === 'production' ? 'https' : 'http'
const baseUrl  = `${protocol}://${host}`
```

**Effect:** All three redirects in the callback now use the dynamic baseUrl:
- `${baseUrl}/login?error=missing_code` (no code)
- `${baseUrl}/login?error=...` (auth failure)
- Final redirect via `destination` (success → `/dashboard`)

A preview login now returns to the preview URL. Production login returns to `craudiovizai.com`.

No session logic, profile upsert, or signup bonus logic modified.

**DO NOT MERGE without Roy's approval.**