### PR TITLE
debug: checkout error trace — CHECKOUT HIT, STRIPE KEY, full error [Apr 13 2026]

### DIFF
--- a/app/api/billing/checkout/route.ts
+++ b/app/api/billing/checkout/route.ts
@@ -1,7 +1,7 @@
 // app/api/billing/checkout/route.ts
 // Central billing authority — Stripe Checkout session creation.
 // Supports both subscription (plan upgrades) and payment (credit pack one-time) modes.
-// Updated: March 26, 2026 — vault-first STRIPE_SECRET_KEY via getSecret().
+// Updated: April 13, 2026 — env-split price IDs; STRIPE_PRICE_TEST/LIVE vars active.
 //
 // POST { priceId, userId, email, mode?, successUrl?, cancelUrl? }
 // mode: "subscription" (default) | "payment"

--- a/app/api/billing/checkout/route.ts
+++ b/app/api/billing/checkout/route.ts
@@ -54,6 +54,13 @@ const PACK_CREDITS: Record<string, number> = {
 }
 
 export async function POST(req: NextRequest) {
+  console.log('CHECKOUT HIT', {
+    host:     req.headers.get('host'),
+    origin:   req.headers.get('origin'),
+    method:   req.method,
+  })
+  console.log('STRIPE KEY EXISTS:', !!process.env.STRIPE_SECRET_KEY,
+    '| prefix:', process.env.STRIPE_SECRET_KEY?.substring(0, 7) ?? 'MISSING')
   try {
     const body = await req.json()
     const {
@@ -175,7 +182,11 @@ export async function POST(req: NextRequest) {
 
   } catch (err: unknown) {
     const msg = err instanceof Error ? err.message : String(err)
-    console.error('[billing/checkout] error:', msg)
+    console.error('CHECKOUT ERROR FULL', {
+      message: msg,
+      type:    err instanceof Error ? err.constructor.name : typeof err,
+      stack:   err instanceof Error ? err.stack?.split('\n').slice(0, 5).join(' | ') : undefined,
+    })
     return NextResponse.json({ error: msg }, { status: 500 })
   }
 }


### PR DESCRIPTION
Adds 3 temporary logs to `app/api/billing/checkout/route.ts` for error diagnosis.

**Log 1 — top of POST handler:**
```
CHECKOUT HIT { host, origin, method }
STRIPE KEY EXISTS: true | prefix: sk_live_ (or sk_test_ or MISSING)
```

**Log 2 — upgraded catch block:**
```
CHECKOUT ERROR FULL { message, type, stack (first 5 frames) }
```

**No logic changes.** Existing `try/catch` structure untouched. Only the error log detail is upgraded.

**Procedure:**
1. Open preview URL `/dashboard`
2. Click **Buy Credits**
3. Check Vercel runtime logs for `CHECKOUT HIT`, `STRIPE KEY EXISTS`, and `CHECKOUT ERROR FULL`
4. Paste log output — diagnosis follows immediately

**Remove after diagnosis. DO NOT MERGE to production.**