### PR TITLE
fix: env-based Stripe price IDs in frontend — test on preview, live on production [Apr 13 2026]

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -131,11 +131,27 @@ function AccountColumn({ user, credits, plan, isAdmin }: {
   async function handleBuyCredits() {
     setBuyLoading(true)
     try {
+      // ── Env-safe price ID — test on preview, live on production ──────────
+      const isProduction = process.env.NODE_ENV === 'production'
+      const PRICE_MAP = isProduction
+        ? {
+            credits_50:   process.env.NEXT_PUBLIC_STRIPE_PRICE_LIVE_CREDITS_50,
+            credits_150:  process.env.NEXT_PUBLIC_STRIPE_PRICE_LIVE_CREDITS_150,
+            credits_525:  process.env.NEXT_PUBLIC_STRIPE_PRICE_LIVE_CREDITS_525,
+            credits_1300: process.env.NEXT_PUBLIC_STRIPE_PRICE_LIVE_CREDITS_1300,
+          }
+        : {
+            credits_50:   process.env.NEXT_PUBLIC_STRIPE_PRICE_TEST_CREDITS_50,
+            credits_150:  process.env.NEXT_PUBLIC_STRIPE_PRICE_TEST_CREDITS_150,
+            credits_525:  process.env.NEXT_PUBLIC_STRIPE_PRICE_TEST_CREDITS_525,
+            credits_1300: process.env.NEXT_PUBLIC_STRIPE_PRICE_TEST_CREDITS_1300,
+          }
+
       const res = await fetch('/api/billing/checkout', {
         method:  'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-          priceId:    'price_1SdaLa7YeQ1dZTUvsjFZWqjB',
+          priceId:    PRICE_MAP.credits_150,
           userId:     user?.id ?? '',
           email:      user?.email ?? '',
           mode:       'payment',


### PR DESCRIPTION
Fixes `handleBuyCredits()` in `app/dashboard/page.tsx` — was hardcoding `price_1SdaLa7YeQ1dZTUvsjFZWqjB` (live Credits 150) regardless of environment.

**Change:**
```typescript
// Before
priceId: 'price_1SdaLa7YeQ1dZTUvsjFZWqjB'

// After
const isProduction = process.env.NODE_ENV === 'production'
const PRICE_MAP = isProduction
  ? { credits_150: process.env.NEXT_PUBLIC_STRIPE_PRICE_LIVE_CREDITS_150, ... }
  : { credits_150: process.env.NEXT_PUBLIC_STRIPE_PRICE_TEST_CREDITS_150, ... }
priceId: PRICE_MAP.credits_150
```

**8 new env vars added to Vercel:**
- `NEXT_PUBLIC_STRIPE_PRICE_TEST_CREDITS_*` → preview + development
- `NEXT_PUBLIC_STRIPE_PRICE_LIVE_CREDITS_*` → production only

**Preview behavior:** `PRICE_MAP.credits_150` resolves to `price_1TLpfF7WStdnOczMQUAzDaOp` (test) → backend validation passes → Stripe creates `cs_test_` session.

**Production behavior:** resolves to `price_1SdaLa7YeQ1dZTUvsjFZWqjB` (live) → Stripe creates `cs_live_` session.

**Untouched:** all other dashboard logic, success/cancel URLs, loading state, error handling, `lib/pricing/config.ts` (separate concern).

**DO NOT MERGE without Roy's approval.**