### PR TITLE
fix: checkout request — userId, email, auth guard + env-safe priceId [Apr 13 2026]

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -131,11 +131,27 @@ function AccountColumn({ user, credits, plan, isAdmin }: {
   async function handleBuyCredits() {
     setBuyLoading(true)
     try {
+      // ── Env-safe price ID — test on preview, live on production ──────────
+      const isProduction = process.env.NODE_ENV === 'production'
+      const PRICE_MAP = isProduction
+        ? {
+            credits_50:   process.env.NEXT_PUBLIC_STRIPE_PRICE_LIVE_CREDITS_50,
+            credits_150:  process.env.NEXT_PUBLIC_STRIPE_PRICE_LIVE_CREDITS_150,
+            credits_525:  process.env.NEXT_PUBLIC_STRIPE_PRICE_LIVE_CREDITS_525,
+            credits_1300: process.env.NEXT_PUBLIC_STRIPE_PRICE_LIVE_CREDITS_1300,
+          }
+        : {
+            credits_50:   process.env.NEXT_PUBLIC_STRIPE_PRICE_TEST_CREDITS_50,
+            credits_150:  process.env.NEXT_PUBLIC_STRIPE_PRICE_TEST_CREDITS_150,
+            credits_525:  process.env.NEXT_PUBLIC_STRIPE_PRICE_TEST_CREDITS_525,
+            credits_1300: process.env.NEXT_PUBLIC_STRIPE_PRICE_TEST_CREDITS_1300,
+          }
+
       const res = await fetch('/api/billing/checkout', {
         method:  'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-          priceId:    'price_1SdaLa7YeQ1dZTUvsjFZWqjB',
+          priceId:    PRICE_MAP.credits_150,
           userId:     user?.id ?? '',
           email:      user?.email ?? '',
           mode:       'payment',

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -130,6 +130,11 @@ function AccountColumn({ user, credits, plan, isAdmin }: {
 
   async function handleBuyCredits() {
     setBuyLoading(true)
+    if (!user) {
+      alert('User not authenticated')
+      setBuyLoading(false)
+      return
+    }
     try {
       // ── Env-safe price ID — test on preview, live on production ──────────
       const isProduction = process.env.NODE_ENV === 'production'


### PR DESCRIPTION
Builds on PR #81 (env-safe PRICE_MAP). Adds the missing auth safety check to `handleBuyCredits()` in `app/dashboard/page.tsx`.

**State of the checkout request after this PR:**
```typescript
// Guard — fires before any fetch
if (!user) {
  alert('User not authenticated')
  setBuyLoading(false)
  return
}

// Env-safe price
const PRICE_MAP = isProduction
  ? { credits_150: process.env.NEXT_PUBLIC_STRIPE_PRICE_LIVE_CREDITS_150 }
  : { credits_150: process.env.NEXT_PUBLIC_STRIPE_PRICE_TEST_CREDITS_150 }

// Fetch body
body: JSON.stringify({
  priceId:    PRICE_MAP.credits_150,   // test or live based on env
  userId:     user?.id ?? '',           // from useAuth()
  email:      user?.email ?? '',        // from useAuth()
  mode:       'payment',
  successUrl: window.location.origin + '/dashboard?success=credits',
  cancelUrl:  window.location.origin + '/dashboard',
})
```

**Note:** `userId` and `email` were already present in PR #81 — sourced from `useAuth()` which provides the Supabase session synchronously. No `supabase.auth.getUser()` call needed — that would be a redundant async call to the same data already in context.

**DO NOT MERGE without Roy's approval.**