### PR TITLE
debug: log Stripe key mode to verify environment mismatch [Apr 14 2026]

### DIFF
--- a/app/api/billing/checkout/route.ts
+++ b/app/api/billing/checkout/route.ts
@@ -22,6 +22,9 @@ function getStripe() {
 
   console.log('STRIPE KEY PREFIX:', key.slice(0, 7))
 
+  const isTestMode = key.startsWith('sk_test_')
+  console.log('STRIPE MODE DETECTED:', isTestMode ? 'TEST' : 'LIVE')
+
   return new Stripe(key, {
     apiVersion: '2024-06-20',
   })


### PR DESCRIPTION
Adds `isTestMode` detection and log inside `getStripe()` in `app/api/billing/checkout/route.ts`.

**Added after existing `STRIPE KEY PREFIX` log:**
```typescript
const isTestMode = key.startsWith('sk_test_')
console.log('STRIPE MODE DETECTED:', isTestMode ? 'TEST' : 'LIVE')
```

**Expected runtime logs on checkout:**
- Preview: `STRIPE KEY PREFIX: sk_test_` | `STRIPE MODE DETECTED: TEST`
- Production: `STRIPE KEY PREFIX: sk_live_` | `STRIPE MODE DETECTED: LIVE`

No logic changes. Roy approved merge.