### PR TITLE
debug: log frontend price selection for Stripe checkout [Apr 14 2026]

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -149,6 +149,10 @@ function AccountColumn({ user, credits, plan, isAdmin }: {
       if (!priceId) {
         throw new Error('Missing priceId env variable')
       }
+      console.log('ENV NODE_ENV:', process.env.NODE_ENV)
+      console.log('LIVE PRICE ENV:', process.env.NEXT_PUBLIC_STRIPE_PRICE_LIVE_CREDITS_150)
+      console.log('TEST PRICE ENV:', process.env.NEXT_PUBLIC_STRIPE_PRICE_TEST_CREDITS_150)
+      console.log('FINAL priceId being sent:', priceId)
       const res = await fetch('/api/billing/checkout', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },


### PR DESCRIPTION
Adds 4 `console.log` statements directly above the `fetch` call in `handleBuyCredits()` in `app/dashboard/page.tsx`.

**Logs added (browser DevTools only — client component):**
```
ENV NODE_ENV: production (or development)
LIVE PRICE ENV: price_1SdaLa... (or undefined on preview)
TEST PRICE ENV: price_1TLpfF... (or undefined on production)
FINAL priceId being sent: price_1TLpfF... (or price_1SdaLa...)
```

⚠️  `NEXT_PUBLIC_` vars in client components log in **browser DevTools**, not in Vercel runtime logs. Open DevTools Console before clicking Buy Credits.

No logic changes. Roy approved merge.