### PR TITLE
fix: auth guard — id/email check after getUser() in handleBuyCredits [Apr 14 2026]

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -142,6 +142,11 @@ function AccountColumn({ user, credits, plan, isAdmin }: {
         setBuyLoading(false)
         return
       }
+      if (!user?.id || !user?.email) {
+        alert('Session not ready. Please wait 2 seconds and try again.')
+        setBuyLoading(false)
+        return
+      }
       const isProduction = process.env.NODE_ENV === 'production'
       const priceId = isProduction
         ? process.env.NEXT_PUBLIC_STRIPE_PRICE_LIVE_CREDITS_150


### PR DESCRIPTION
Adds explicit `id` and `email` guard after `supabase.auth.getUser()` in `handleBuyCredits()`.

**Added guard:**
```typescript
if (!user?.id || !user?.email) {
  alert('Session not ready. Please wait 2 seconds and try again.')
  setBuyLoading(false)
  return
}
```

**Not changed:** `window.location.hostname` not used — kept `NODE_ENV`-based price selection which is already correct and more reliable. Vercel injects `NODE_ENV=production` on production builds only.

Roy approved merge.