### PR TITLE
fix: use session-aware Supabase client in handleBuyCredits [Apr 14 2026]

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -9,6 +9,7 @@
 import React, { useState, useEffect } from 'react';
 import Link from 'next/link';
 import { useAuth } from '@/app/providers';
+import { createClientComponentClient } from '@supabase/auth-helpers-nextjs'
 
 // =============================================================================
 // LOADING SKELETON
@@ -131,11 +132,7 @@ function AccountColumn({ user, credits, plan, isAdmin }: {
   async function handleBuyCredits() {
     try {
       setBuyLoading(true)
-      const { createClient } = await import('@supabase/supabase-js')
-      const supabase = createClient(
-        process.env.NEXT_PUBLIC_SUPABASE_URL!,
-        process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
-      )
+      const supabase = createClientComponentClient()
       const { data: { user } } = await supabase.auth.getUser()
       if (!user) {
         alert('You must be logged in')


### PR DESCRIPTION
**Root cause:** `handleBuyCredits()` was calling `createClient()` with just the anon key — a fresh unauthenticated client with no session cookie. `getUser()` on that client always returns `null` even when the user is logged in.

**Fix:** Replace with `createClientComponentClient()` from `@supabase/auth-helpers-nextjs` — this reads the existing session cookie and returns the authenticated user correctly.

**Before:**
```typescript
const { createClient } = await import('@supabase/supabase-js')
const supabase = createClient(
  process.env.NEXT_PUBLIC_SUPABASE_URL!,
  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
)
```

**After:**
```typescript
const supabase = createClientComponentClient()
```

Everything else in `handleBuyCredits()` unchanged: `getUser()`, guards, price selection, fetch body, debug logs.

No new Supabase clients created anywhere in the function.

Roy approved merge.