### PR TITLE
fix: single NEXT_PUBLIC_STRIPE_PRICE_CREDITS_150 — Vercel-bound per env [Apr 16 2026]

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -136,10 +136,7 @@ function AccountColumn({ user, credits, plan, isAdmin }: {
         setBuyLoading(false)
         return
       }
-      const isProduction = process.env.NODE_ENV === 'production'
-      const priceId = isProduction
-        ? process.env.NEXT_PUBLIC_STRIPE_PRICE_LIVE_CREDITS_150
-        : process.env.NEXT_PUBLIC_STRIPE_PRICE_TEST_CREDITS_150
+      const priceId = process.env.NEXT_PUBLIC_STRIPE_PRICE_CREDITS_150
       if (!priceId) {
         throw new Error('Missing priceId env variable')
       }


### PR DESCRIPTION
**Root cause fixed:** `NODE_ENV` is always `production` at Next.js build time — even on preview builds. The `isProduction` ternary was being tree-shaken to always use the live price ID regardless of environment.

**Fix:** Single env var `NEXT_PUBLIC_STRIPE_PRICE_CREDITS_150` with Vercel-managed per-environment values:
- production → `price_1SdaLa7YeQ1dZTUvsjFZWqjB` (live)
- preview → `price_1TLpfF7WStdnOczMQUAzDaOp` (test)
- development → `price_1TLpfF7WStdnOczMQUAzDaOp` (test)

**Code change:**
```typescript
// Before (broken — NODE_ENV always 'production' at build time)
const isProduction = process.env.NODE_ENV === 'production'
const priceId = isProduction
  ? process.env.NEXT_PUBLIC_STRIPE_PRICE_LIVE_CREDITS_150
  : process.env.NEXT_PUBLIC_STRIPE_PRICE_TEST_CREDITS_150

// After (correct — Vercel injects right value per env at build time)
const priceId = process.env.NEXT_PUBLIC_STRIPE_PRICE_CREDITS_150
```

Deleted: `NEXT_PUBLIC_STRIPE_PRICE_TEST_CREDITS_150`, `NEXT_PUBLIC_STRIPE_PRICE_LIVE_CREDITS_150` from Vercel.

Roy approved merge.