### PR TITLE
fix: enforce frontend redirect to Stripe checkout [Apr 17 2026]

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -154,13 +154,18 @@ function AccountColumn({ user, credits, plan, isAdmin }: {
         })
       })
       const data = await res.json()
+      console.log('CHECKOUT FRONTEND RESPONSE', data)
       if (!res.ok) {
-        throw new Error(data.error || 'Checkout failed')
+        alert(data.error || 'Checkout failed')
+        return
+      }
+      if (!data?.url) {
+        alert('No checkout URL returned')
+        return
       }
       window.location.href = data.url
     } catch (err) {
       console.error('Checkout failed', err)
-      alert('Unable to start checkout. Please try again.')
     } finally {
       setBuyLoading(false)
     }


### PR DESCRIPTION
Replaces fetch handling block in `handleBuyCredits()`.

**Changes:**
- Added `console.log('CHECKOUT FRONTEND RESPONSE', data)` after `res.json()`
- `!res.ok` → `alert(data.error)` + `return` (no throw)
- Added `!data?.url` guard → `alert('No checkout URL returned')` + `return`
- `window.location.href = data.url` remains as final redirect
- Catch no longer alerts — just logs

**Removed:** `throw new Error(...)`, `alert('Unable to start checkout...')`

Roy approved merge.