### PR TITLE
debug: PROD STRIPE DEBUG log before session creation [Apr 17 2026]

### DIFF
--- a/app/api/billing/checkout/route.ts
+++ b/app/api/billing/checkout/route.ts
@@ -131,6 +131,12 @@ export async function POST(req: NextRequest) {
       }
     }
 
+    console.log('PROD STRIPE DEBUG', {
+      keyPrefix: process.env.STRIPE_SECRET_KEY?.slice(0, 10),
+      hasKey:    !!process.env.STRIPE_SECRET_KEY,
+      priceId,
+    })
+
     // ── Subscription mode ──────────────────────────────────────────────────────────
     if (mode === 'subscription') {
       const session = await s.checkout.sessions.create({


### PR DESCRIPTION
Adds `PROD STRIPE DEBUG` log in `app/api/billing/checkout/route.ts` immediately before the first `sessions.create` call.

```typescript
console.log('PROD STRIPE DEBUG', {
  keyPrefix: process.env.STRIPE_SECRET_KEY?.slice(0, 10),
  hasKey:    !!process.env.STRIPE_SECRET_KEY,
  priceId,
})
```

`CHECKOUT ERROR FULL` already confirmed present in catch from PR #95.

Roy approved merge.