### PR TITLE
security: webhook idempotency protection [Apr 17 2026]

### DIFF
--- a/app/api/billing/webhook/route.ts
+++ b/app/api/billing/webhook/route.ts
@@ -188,25 +188,27 @@ export async function POST(req: NextRequest) {
   }
 
   console.log('WEBHOOK RECEIVED', event.type)
-  console.log('EVENT ID', event.id.slice(0, 24) + '...')
+  const eventId = event.id
+  console.log('WEBHOOK EVENT ID', eventId)
 
   // ── Idempotency guard ──────────────────────────────────────────────────────
   const { data: existing } = await supabase
     .from('billing_events')
     .select('id')
-    .eq('stripe_event_id', event.id)
+    .eq('stripe_event_id', eventId)
     .eq('processed', true)
     .maybeSingle()
 
   if (existing) {
-    console.log(`[billing/webhook] duplicate skipped: ${event.id}`)
+    console.log('DUPLICATE WEBHOOK IGNORED', eventId)
     return new Response(JSON.stringify({ received: true, skipped: 'duplicate' }), { status: 200 })
   }
 
   // ── Log raw event ─────────────────────────────────────────────────────────
   await supabase.from('billing_events').upsert({
-    stripe_event_id: event.id,
+    stripe_event_id: eventId,
     event_type:      event.type,
+    created_at:      new Date(event.created * 1000).toISOString(),
     payload:         event.data as Record<string, unknown>,
     processed:       false,
   }, { onConflict: 'stripe_event_id' })
@@ -311,8 +313,9 @@ export async function POST(req: NextRequest) {
 
     await supabase.from('billing_events')
       .update({ processed: true })
-      .eq('stripe_event_id', event.id)
+      .eq('stripe_event_id', eventId)
 
+    console.log('WEBHOOK PROCESSED ONCE', eventId)
     return new Response(JSON.stringify({ received: true }), { status: 200 })
 
   } catch (err: unknown) {


### PR DESCRIPTION
Upgrades idempotency logging in `app/api/billing/webhook/route.ts`.

**The idempotency mechanism already existed** (`billing_events` check + `processed` flag). This PR standardises the log labels and variable usage.

**Changes:**
- `const eventId = event.id` extracted at top of handler
- `WEBHOOK EVENT ID eventId` log (was `EVENT ID event.id.slice(...)`)
- `DUPLICATE WEBHOOK IGNORED eventId` (was `duplicate skipped: ${event.id}`)
- `WEBHOOK PROCESSED ONCE eventId` added after `processed: true` update
- All DB calls use `eventId` variable (no raw `event.id` in DB paths)
- `created_at: new Date(event.created * 1000).toISOString()` added to insert

**Unchanged:** signature verification, `billing_events` dedup logic, credit grant flow, subscription handling.

Roy approved merge.