### PR TITLE
security: refund idempotency protection [Apr 18 2026]

### DIFF
--- a/app/api/billing/webhook/route.ts
+++ b/app/api/billing/webhook/route.ts
@@ -338,6 +338,18 @@ export async function POST(req: NextRequest) {
           (amountRefunded / amountTotal) * creditsGranted
         )
 
+        // Prevent duplicate refund credit reversals
+        const existingRefund = await supabase
+          .from('usage_ledger')
+          .select('id')
+          .eq('metadata->>stripe_event_id', eventId)
+          .limit(1)
+
+        if ((existingRefund.data?.length ?? 0) > 0) {
+          console.log('DUPLICATE REFUND IGNORED', eventId)
+          break
+        }
+
         await supabase.from('usage_ledger').insert({
           user_id:     userId,
           feature:     'credits',
@@ -352,6 +364,7 @@ export async function POST(req: NextRequest) {
           },
         })
 
+        console.log('REFUND APPLIED ONCE', eventId)
         console.log('REFUND PROCESSED', {
           userId:         userId.slice(0, 8) + '…',
           credits_removed,


### PR DESCRIPTION
Hardens `charge.refunded` / `charge.refund.updated` handler in `app/api/billing/webhook/route.ts`.

**Inserted before `usage_ledger` insert:**
```typescript
// Prevent duplicate refund credit reversals
const existingRefund = await supabase
  .from('usage_ledger')
  .select('id')
  .eq('metadata->>stripe_event_id', eventId)
  .limit(1)

if ((existingRefund.data?.length ?? 0) > 0) {
  console.log('DUPLICATE REFUND IGNORED', eventId)
  break
}
```

**Added after insert:**
```typescript
console.log('REFUND APPLIED ONCE', eventId)
```

**Why `?? 0`:** `existingRefund.data` can be `null` on Supabase error — defaults to 0 rather than throwing, so the insert proceeds safely.

Roy approved merge.