### PR TITLE
perf: indexable stripe_event_id for refund idempotency [Apr 18 2026]

### DIFF
--- a/app/api/billing/webhook/route.ts
+++ b/app/api/billing/webhook/route.ts
@@ -339,10 +339,11 @@ export async function POST(req: NextRequest) {
         )
 
         // Prevent duplicate refund credit reversals
+        // stripe_event_id duplicated at top-level for fast indexed lookup
         const existingRefund = await supabase
           .from('usage_ledger')
           .select('id')
-          .eq('metadata->>stripe_event_id', eventId)
+          .eq('stripe_event_id', eventId)
           .limit(1)
 
         if ((existingRefund.data?.length ?? 0) > 0) {
@@ -351,13 +352,14 @@ export async function POST(req: NextRequest) {
         }
 
         await supabase.from('usage_ledger').insert({
-          user_id:     userId,
-          feature:     'credits',
-          usage_count: credits_removed,
+          user_id:          userId,
+          feature:          'credits',
+          usage_count:      credits_removed,
+          stripe_event_id:  eventId,         // top-level for indexed lookup
           metadata: {
             type:            'refund',
             source:          'stripe_refund',
-            stripe_event_id: eventId,
+            stripe_event_id: eventId,         // kept in metadata for audit trail
             amount_refunded: amountRefunded,
             amount_total:    amountTotal,
             credits_granted: creditsGranted,


### PR DESCRIPTION
Improves refund lookup performance in `app/api/billing/webhook/route.ts`.

**Problem:** Idempotency check was using PostgREST JSON path operator `metadata->>stripe_event_id` — cannot use a btree index, always a full scan.

**Fix:** Add `stripe_event_id` as a top-level column in the `usage_ledger` insert so the lookup can hit a standard indexed column.

**Changes:**
```typescript
// Before
.eq('metadata->>stripe_event_id', eventId)   // JSON scan

// After
.eq('stripe_event_id', eventId)              // indexed column
```

**Insert now writes to both:**
```typescript
stripe_event_id:  eventId,         // top-level for indexed lookup
metadata: {
  stripe_event_id: eventId,        // kept in metadata for audit trail
  ...
}
```

**Note:** `usage_ledger` table needs a `stripe_event_id` column if it doesn't already have one. DDL: `ALTER TABLE usage_ledger ADD COLUMN IF NOT EXISTS stripe_event_id TEXT; CREATE INDEX IF NOT EXISTS idx_usage_ledger_stripe_event_id ON usage_ledger(stripe_event_id);`

Roy approved merge.