### PR TITLE
security: credit floor protection — no negative balances [Apr 18 2026]

### DIFF
--- a/app/api/billing/usage/route.ts
+++ b/app/api/billing/usage/route.ts
@@ -2,7 +2,7 @@
 // Central billing authority — usage recording and summary.
 // POST { userId, feature, count? } — record usage
 // GET  ?userId=&feature= — get today + month summary
-// Thursday, March 19, 2026
+// Updated: April 18, 2026 — credit floor protection (no negative balances)
 import { NextRequest, NextResponse } from 'next/server'
 import { createClient } from '@supabase/supabase-js'
 
@@ -14,6 +14,23 @@ function db() {
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
     process.env.SUPABASE_SERVICE_ROLE_KEY!,
   )
+}
+
+// ── Credit floor helper ────────────────────────────────────────────────────────
+// Returns the current net credit balance for a user.
+// Positive = credits available. Negative = already over-debited (should not occur).
+async function getNetCreditBalance(
+  supabase: ReturnType<typeof db>,
+  userId:   string,
+): Promise<number> {
+  const { data: rows, error } = await supabase
+    .from('usage_ledger')
+    .select('usage_count')
+    .eq('user_id', userId)
+    .eq('feature', 'credits')
+
+  if (error) throw new Error(`credit balance query failed: ${error.message}`)
+  return (rows ?? []).reduce((sum, r) => sum + (r.usage_count ?? 0), 0)
 }
 
 export async function POST(req: NextRequest) {
@@ -28,7 +45,36 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: 'count must be 1-1000' }, { status: 400 })
     }
 
-    const { error } = await db().from('usage_ledger').insert({
+    const supabase = db()
+
+    // ── Credit floor protection ─────────────────────────────────────────────
+    // For credit-feature deductions, verify the user has sufficient balance
+    // before recording. Grants (positive inserts) bypass this check.
+    // This endpoint records usage as POSITIVE counts (AI consumption deducts
+    // from balance by adding positive usage against negative-balance accounting).
+    // The balance check: currentBalance - count >= 0
+    if (feature === 'credits') {
+      const currentBalance = await getNetCreditBalance(supabase, userId)
+      // usage_count in this route is always positive (consumption)
+      // balance decreases as grants are positive and usage is also positive,
+      // but net is computed as: grants (positive rows with type:grant) minus
+      // usage rows. If this route inserts positive rows as usage, we need to
+      // check if the current ledger SUM (which accounts for both grants and
+      // deductions already written) minus this new deduction stays >= 0.
+      if (currentBalance - count < 0) {
+        console.warn('CREDIT FLOOR BLOCKED', {
+          userId:           userId.slice(0, 8) + '…',
+          attempted_change: -count,
+          current_total:    currentBalance,
+        })
+        return NextResponse.json(
+          { error: 'INSUFFICIENT_CREDITS', current_balance: Math.max(0, currentBalance) },
+          { status: 402 }
+        )
+      }
+    }
+
+    const { error } = await supabase.from('usage_ledger').insert({
       user_id:     userId,
       feature,
       usage_count: count,

--- a/app/api/billing/webhook/route.ts
+++ b/app/api/billing/webhook/route.ts
@@ -67,6 +67,21 @@ function db() {
   )
 }
 
+// ── Credit floor helper ────────────────────────────────────────────────────
+// Returns the current net credit balance for a user (grants + deductions).
+async function getNetCreditBalance(
+  supabase: ReturnType<typeof db>,
+  userId:   string,
+): Promise<number> {
+  const { data: rows, error } = await supabase
+    .from('usage_ledger')
+    .select('usage_count')
+    .eq('user_id', userId)
+    .eq('feature', 'credits')
+  if (error) throw new Error(`credit balance query failed: ${error.message}`)
+  return (rows ?? []).reduce((sum, r) => sum + (r.usage_count ?? 0), 0)
+}
+
 // ── Subscription plan → monthly credit grant ──────────────────────────────────
 const SUBSCRIPTION_CREDIT_MAP: Record<string, number> = {
   'price_1SdaKx7YeQ1dZTUvCeaYqKXh': 150,   // Starter Plan  ($9.99/mo)
@@ -351,10 +366,29 @@ export async function POST(req: NextRequest) {
           break
         }
 
+        // ── Credit floor protection ───────────────────────────────────────
+        const currentBalance  = await getNetCreditBalance(supabase, userId)
+        let finalRemoval      = credits_removed   // already negative
+
+        if (currentBalance + credits_removed < 0) {
+          // Clamp: only remove credits the user actually has
+          finalRemoval = -Math.min(Math.abs(credits_removed), Math.max(0, currentBalance))
+          console.warn('CREDIT FLOOR BLOCKED', {
+            userId:           userId.slice(0, 8) + '…',
+            attempted_change: credits_removed,
+            current_total:    currentBalance,
+            clamped_to:       finalRemoval,
+          })
+          if (finalRemoval === 0) {
+            console.warn('[billing/webhook] refund — user already at zero balance, skipping reversal')
+            break
+          }
+        }
+
         await supabase.from('usage_ledger').insert({
           user_id:          userId,
           feature:          'credits',
-          usage_count:      credits_removed,
+          usage_count:      finalRemoval,
           stripe_event_id:  eventId,         // top-level for indexed lookup
           metadata: {
             type:            'refund',
@@ -363,13 +397,15 @@ export async function POST(req: NextRequest) {
             amount_refunded: amountRefunded,
             amount_total:    amountTotal,
             credits_granted: creditsGranted,
+            original_removal: credits_removed,
+            floor_clamped:   finalRemoval !== credits_removed,
           },
         })
 
         console.log('REFUND APPLIED ONCE', eventId)
         console.log('REFUND PROCESSED', {
           userId:         userId.slice(0, 8) + '…',
-          credits_removed,
+          credits_removed: finalRemoval,
           amountRefunded,
           amountTotal,
           eventId:        eventId.slice(0, 20) + '...',


### PR DESCRIPTION
Adds server-side credit floor enforcement to prevent negative balances.

## Files modified

### `app/api/billing/usage/route.ts`
- Added `getNetCreditBalance()` helper — `SUM(usage_count) WHERE user_id AND feature='credits'`
- Before any `feature === 'credits'` insert: checks `currentBalance - count >= 0`
- If insufficient: returns HTTP 402 `INSUFFICIENT_CREDITS` — does NOT insert
- Logs `CREDIT FLOOR BLOCKED` with userId, attempted_change, current_total
- Grants (positive rows from webhook) are NOT routed through this endpoint

### `app/api/billing/webhook/route.ts`
- Added `getNetCreditBalance()` helper (same logic)
- Before refund insert: checks `currentBalance + credits_removed >= 0`
- If it would go negative: **clamps** to available balance (not hard block)
- If already at zero: logs and breaks with no insert
- Logs `CREDIT FLOOR BLOCKED` with clamped_to value
- Stores `floor_clamped: true` in ledger metadata when clamping occurs

## Behaviour difference: block vs clamp
Usage deductions (AI consumption) → **block** (402 INSUFFICIENT_CREDITS)
Refund reversals → **clamp** (Stripe refund is valid even if credits were spent)

Roy approved merge.