### PR TITLE
admin: billing exec layer observability + Javari router [Apr 22 2026]

### DIFF
--- a/app/api/admin/credits/route.ts
+++ b/app/api/admin/credits/route.ts
@@ -1,13 +1,21 @@
 // app/api/admin/credits/route.ts
-// Admin observability — usage_ledger grouped by user_id with total credits.
-// Auth: Bearer token from Authorization header, admin email allowlist.
-// Updated: April 18, 2026
+// ─────────────────────────────────────────────────────────────────────────────
+// CANONICAL ROLE: Admin UI observability — read-only credit ledger data.
+// CALLED BY: /admin dashboard page (browser, admin users only).
+// AUTOMATION: Use /api/internal/exec?action=list_ledger for server-side ops.
+// NOTE: Admin UI routes stay open to authenticated admin browsers.
+//       BILLING_EXEC_MODE=internal_only logs a warning but does not block.
+// ─────────────────────────────────────────────────────────────────────────────
+// Auth: Bearer token from Authorization header, ADMIN_EMAILS allowlist.
+// Updated: April 22, 2026 — exec layer observability
 
 import { NextRequest, NextResponse } from 'next/server'
 import { createClient } from '@supabase/supabase-js'
 
 export const dynamic = 'force-dynamic'
 export const runtime  = 'nodejs'
+
+const ROUTE_PATH = '/api/admin/credits'
 
 // ── Admin auth ────────────────────────────────────────────────────────────────
 const ADMIN_EMAILS = [
@@ -46,6 +54,17 @@ async function verifyAdmin(
   return {}
 }
 
+// ── Exec-layer observability ──────────────────────────────────────────────────
+function logDirectAccess(method: string) {
+  const execMode = process.env.BILLING_EXEC_MODE ?? 'standard'
+  console.warn('DIRECT BILLING ROUTE ACCESS', {
+    path:     ROUTE_PATH,
+    method,
+    exec_mode: execMode,
+    note:     'Admin UI route — browser access expected. Automation: /api/internal/exec',
+  })
+}
+
 // ── GET /api/admin/credits ────────────────────────────────────────────────────
 // Query params:
 //   user_id — filter to a specific user
@@ -55,6 +74,8 @@ async function verifyAdmin(
 export async function GET(req: NextRequest) {
   const { error } = await verifyAdmin(req)
   if (error) return error
+
+  logDirectAccess('GET')
 
   const { searchParams } = new URL(req.url)
   const userId = searchParams.get('user_id') ?? undefined

--- a/app/api/admin/payments/route.ts
+++ b/app/api/admin/payments/route.ts
@@ -1,7 +1,13 @@
 // app/api/admin/payments/route.ts
-// Admin observability — recent Stripe checkout sessions + metadata.
-// Auth: Bearer token from Authorization header, admin email allowlist.
-// Updated: April 18, 2026
+// ─────────────────────────────────────────────────────────────────────────────
+// CANONICAL ROLE: Admin UI observability — read-only Stripe session data.
+// CALLED BY: /admin dashboard page (browser, admin users only).
+// AUTOMATION: Use /api/internal/exec for server-side admin operations.
+// NOTE: Admin UI routes stay open to authenticated admin browsers.
+//       BILLING_EXEC_MODE=internal_only logs a warning but does not block.
+// ─────────────────────────────────────────────────────────────────────────────
+// Auth: Bearer token from Authorization header, ADMIN_EMAILS allowlist.
+// Updated: April 22, 2026 — exec layer observability
 
 import { NextRequest, NextResponse } from 'next/server'
 import Stripe from 'stripe'
@@ -9,6 +15,8 @@ import { createClient } from '@supabase/supabase-js'
 
 export const dynamic = 'force-dynamic'
 export const runtime  = 'nodejs'
+
+const ROUTE_PATH = '/api/admin/payments'
 
 // ── Admin auth ────────────────────────────────────────────────────────────────
 const ADMIN_EMAILS = [
@@ -53,6 +61,17 @@ function getStripe() {
   return new Stripe(key, { apiVersion: '2024-06-20' })
 }
 
+// ── Exec-layer observability ──────────────────────────────────────────────────
+function logDirectAccess(method: string) {
+  const execMode = process.env.BILLING_EXEC_MODE ?? 'standard'
+  console.warn('DIRECT BILLING ROUTE ACCESS', {
+    path:     ROUTE_PATH,
+    method,
+    exec_mode: execMode,
+    note:     'Admin UI route — browser access expected. Automation: /api/internal/exec',
+  })
+}
+
 // ── GET /api/admin/payments ───────────────────────────────────────────────────
 // Query params:
 //   limit   — number of sessions to return (default 20, max 100)
@@ -61,6 +80,8 @@ function getStripe() {
 export async function GET(req: NextRequest) {
   const { error } = await verifyAdmin(req)
   if (error) return error
+
+  logDirectAccess('GET')
 
   const { searchParams } = new URL(req.url)
   const limit  = Math.min(parseInt(searchParams.get('limit')  ?? '20', 10), 100)

--- a/app/api/admin/webhooks/route.ts
+++ b/app/api/admin/webhooks/route.ts
@@ -1,13 +1,21 @@
 // app/api/admin/webhooks/route.ts
-// Admin observability — billing_events table with processing status.
-// Auth: Bearer token from Authorization header, admin email allowlist.
-// Updated: April 18, 2026
+// ─────────────────────────────────────────────────────────────────────────────
+// CANONICAL ROLE: Admin UI observability — read-only billing_events data.
+// CALLED BY: /admin dashboard page (browser, admin users only).
+// AUTOMATION: Use /api/internal/exec?action=replay_webhook for server-side ops.
+// NOTE: Admin UI routes stay open to authenticated admin browsers.
+//       BILLING_EXEC_MODE=internal_only logs a warning but does not block.
+// ─────────────────────────────────────────────────────────────────────────────
+// Auth: Bearer token from Authorization header, ADMIN_EMAILS allowlist.
+// Updated: April 22, 2026 — exec layer observability
 
 import { NextRequest, NextResponse } from 'next/server'
 import { createClient } from '@supabase/supabase-js'
 
 export const dynamic = 'force-dynamic'
 export const runtime  = 'nodejs'
+
+const ROUTE_PATH = '/api/admin/webhooks'
 
 // ── Admin auth ────────────────────────────────────────────────────────────────
 const ADMIN_EMAILS = [
@@ -46,6 +54,17 @@ async function verifyAdmin(
   return {}
 }
 
+// ── Exec-layer observability ──────────────────────────────────────────────────
+function logDirectAccess(method: string) {
+  const execMode = process.env.BILLING_EXEC_MODE ?? 'standard'
+  console.warn('DIRECT BILLING ROUTE ACCESS', {
+    path:     ROUTE_PATH,
+    method,
+    exec_mode: execMode,
+    note:     'Admin UI route — browser access expected. Automation: /api/internal/exec',
+  })
+}
+
 // ── GET /api/admin/webhooks ───────────────────────────────────────────────────
 // Query params:
 //   event_type  — filter by Stripe event type (e.g. 'checkout.session.completed')
@@ -56,6 +75,8 @@ async function verifyAdmin(
 export async function GET(req: NextRequest) {
   const { error } = await verifyAdmin(req)
   if (error) return error
+
+  logDirectAccess('GET')
 
   const { searchParams } = new URL(req.url)
   const eventType = searchParams.get('event_type') ?? undefined

--- a/app/api/billing/usage/route.ts
+++ b/app/api/billing/usage/route.ts
@@ -1,19 +1,44 @@
 // app/api/billing/usage/route.ts
-// Central billing authority — usage recording and summary.
+// ─────────────────────────────────────────────────────────────────────────────
+// CANONICAL ROLE: AI/feature credit consumption recording.
+// CALLED BY: Javari modules, app feature gates, internal platform services.
+// AUTOMATION: Use /api/internal/exec?action=credit_deduct for server-side ops.
+// NOTE: This route stays open to Javari modules — do NOT gate with 403.
+//       BILLING_EXEC_MODE=internal_only logs a warning but does not block,
+//       because Javari apps legitimately call this directly.
+// ─────────────────────────────────────────────────────────────────────────────
 // POST { userId, feature, count? } — record usage
 // GET  ?userId=&feature= — get today + month summary
-// Updated: April 18, 2026 — credit floor + negative usage_count for credits
+// Updated: April 22, 2026 — exec layer observability
+
 import { NextRequest, NextResponse } from 'next/server'
 import { createClient } from '@supabase/supabase-js'
 
 export const dynamic = 'force-dynamic'
 export const runtime = 'nodejs'
 
+const ROUTE_PATH = '/api/billing/usage'
+
 function db() {
   return createClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
     process.env.SUPABASE_SERVICE_ROLE_KEY!,
   )
+}
+
+// ── Exec-layer observability ──────────────────────────────────────────────────
+// Logs when this route is called directly so we can track automation coverage.
+// In internal_only mode: warns but does NOT block (Javari apps call this legitimately).
+function logDirectAccess(method: string) {
+  const execMode = process.env.BILLING_EXEC_MODE ?? 'standard'
+  console.warn('DIRECT BILLING ROUTE ACCESS', {
+    path:     ROUTE_PATH,
+    method,
+    exec_mode: execMode,
+    note:     execMode === 'internal_only'
+      ? 'Consider routing credit ops through /api/internal/exec'
+      : 'standard',
+  })
 }
 
 // ── Credit floor helper ────────────────────────────────────────────────────────
@@ -37,6 +62,8 @@ async function getNetCreditBalance(
 }
 
 export async function POST(req: NextRequest) {
+  logDirectAccess('POST')
+
   try {
     const { userId, feature, count = 1, metadata = {} } =
       await req.json() as { userId: string; feature: string; count?: number; metadata?: Record<string, unknown> }
@@ -53,7 +80,7 @@ export async function POST(req: NextRequest) {
     // ── Credit direction + floor protection ─────────────────────────────────
     // Credits follow signed accounting:
     //   Grants  (webhook)  → positive rows (+N)
-    //   Usage   (this fn)  → negative rows (-N)   ← this is the fix
+    //   Usage   (this fn)  → negative rows (-N)
     //   Refunds (webhook)  → negative rows (-N)
     // The floor guard: currentBalance + usage_count >= 0
     if (feature === 'credits') {
@@ -108,6 +135,8 @@ export async function POST(req: NextRequest) {
 }
 
 export async function GET(req: NextRequest) {
+  logDirectAccess('GET')
+
   try {
     const userId  = req.nextUrl.searchParams.get('userId')
     const feature = req.nextUrl.searchParams.get('feature')

--- a/app/api/billing/webhook/route.ts
+++ b/app/api/billing/webhook/route.ts
@@ -1,24 +1,11 @@
 // app/api/billing/webhook/route.ts
-// Central billing authority — Stripe webhook handler.
-// Handles: checkout.session.completed, customer.subscription.updated/deleted,
-//          invoice.payment_failed, charge.refunded, charge.refund.updated
-// Writes to: user_subscriptions, billing_events, usage_ledger (credits)
-// Updated: April 16, 2026 — getStripe() from process.env.STRIPE_SECRET_KEY. Live webhook secret bound 1776434316.
-//
-// IDEMPOTENCY GUARANTEE:
-//   Every event is logged to billing_events with processed=false on arrival.
-//   Processing only runs when processed=false. After success, set processed=true.
-//   Stripe retries the same event.id → skip guard fires → no double grant.
-//   This holds for both subscription grants and credit pack grants.
-//
-// CREDIT GRANT SOURCES:
-//   subscription  → SUBSCRIPTION_CREDIT_MAP[priceId]   (monthly plan credits)
-//   credit_pack   → metadata.credits_granted            (one-time pack, exact value)
-//                   fallback → PACK_CREDIT_MAP[priceId]
-//
-// PURCHASE TYPE DETECTION:
-//   session.metadata.purchase_type === "credit_pack" → pack flow
-//   session.metadata.purchase_type === undefined      → subscription flow (default)
+// ─────────────────────────────────────────────────────────────────────────────
+// CANONICAL ROLE: Stripe webhook receiver — MUST remain directly accessible.
+// CALLED BY: Stripe (live + test), /api/internal/exec replay_webhook action.
+// AUTOMATION: Use /api/internal/exec?action=replay_webhook to replay events.
+// WARNING: DO NOT block direct POSTs to this route — Stripe cannot be
+//          rerouted through /api/internal/exec. Blocking = broken payments.
+// ─────────────────────────────────────────────────────────────────────────────
 import { NextRequest, NextResponse } from 'next/server'
 import Stripe from 'stripe'
 import { createClient } from '@supabase/supabase-js'
@@ -178,6 +165,17 @@ async function grantCreditsToLedger(
 // ── Webhook POST handler ──────────────────────────────────────────────────────
 export async function POST(req: NextRequest) {
   const corsHeaders = getCorsHeaders(req)
+
+  // ── Exec-layer observability ──────────────────────────────────────────────
+  // Stripe must call this directly — do NOT block.
+  // Logs allow tracking of direct vs replayed webhook delivery.
+  console.warn('DIRECT BILLING ROUTE ACCESS', {
+    path:      '/api/billing/webhook',
+    method:    'POST',
+    exec_mode: process.env.BILLING_EXEC_MODE ?? 'standard',
+    note:      'Stripe webhook — direct access required, never block',
+  })
+
   const supabase    = db()
   const s           = getStripe()
 

--- a/lib/javari/router.ts
+++ b/lib/javari/router.ts
@@ -1,0 +1,172 @@
+// lib/javari/router.ts
+// ─────────────────────────────────────────────────────────────────────────────
+// CANONICAL ROLE: Javari AI intent router — classifies requests and dispatches.
+// DO NOT CALL DIRECTLY from client components — import and use route() or
+//   dispatchBillingIntent() from server-side context only.
+// BILLING: All billing intents route to /api/internal/exec (no browser token).
+// AI:      All generation intents return a model tier for the caller to invoke.
+// COST LAW: gpt-4o-mini (free) → claude-haiku (low) → claude-sonnet (moderate)
+// Updated: April 22, 2026 — billing intent routing to internal exec layer
+// ─────────────────────────────────────────────────────────────────────────────
+
+export type BillingIntent =
+  | 'grant_credits'
+  | 'deduct_credits'
+  | 'get_balance'
+  | 'list_ledger'
+  | 'get_user'
+  | 'replay_webhook'
+  | 'health_check'
+
+export type AIIntent =
+  | 'chat'
+  | 'forge'
+  | 'team'
+  | 'image'
+  | 'audio'
+  | 'code'
+
+export type RouterIntent = BillingIntent | AIIntent | 'unknown'
+
+// ── Intent classification ─────────────────────────────────────────────────────
+const BILLING_KEYWORDS: Record<BillingIntent, string[]> = {
+  grant_credits:    ['grant', 'add credits', 'give credits', 'top up', 'topup', 'credit grant'],
+  deduct_credits:   ['deduct', 'remove credits', 'charge credits', 'consume credits'],
+  get_balance:      ['balance', 'how many credits', 'credit count', 'check credits'],
+  list_ledger:      ['ledger', 'credit history', 'transaction history', 'credit log'],
+  get_user:         ['user info', 'user profile', 'lookup user', 'find user', 'user details'],
+  replay_webhook:   ['replay', 'retry webhook', 'reprocess event', 'replay event'],
+  health_check:     ['health', 'ping', 'status check', 'is running'],
+}
+
+export function classifyIntent(input: string): RouterIntent {
+  const lower = input.toLowerCase()
+  for (const [intent, keywords] of Object.entries(BILLING_KEYWORDS) as [BillingIntent, string[]][]) {
+    if (keywords.some(kw => lower.includes(kw))) return intent
+  }
+  return 'unknown'
+}
+
+// ── Exec layer client ─────────────────────────────────────────────────────────
+// All billing operations route through /api/internal/exec.
+// Uses INTERNAL_API_SECRET — never requires a browser JWT.
+
+export interface ExecParams {
+  action:   string
+  userId?:  string
+  credits?: number
+  eventId?: string
+  email?:   string
+  limit?:   number
+  note?:    string
+}
+
+export interface ExecResult {
+  ok:         boolean
+  action:     string
+  error?:     string
+  [key: string]: unknown
+}
+
+export async function callExec(
+  params:  ExecParams,
+  baseUrl: string = process.env.NEXT_PUBLIC_SITE_URL ?? 'https://craudiovizai.com',
+): Promise<ExecResult> {
+  const secret = process.env.INTERNAL_API_SECRET
+  if (!secret) throw new Error('INTERNAL_API_SECRET not configured')
+
+  // Build query string — filter out undefined values
+  const qs = new URLSearchParams()
+  qs.set('secret', secret)
+  for (const [k, v] of Object.entries(params)) {
+    if (v !== undefined && v !== null) qs.set(k, String(v))
+  }
+
+  const url = `${baseUrl}/api/internal/exec?${qs.toString()}`
+
+  const res  = await fetch(url, { method: 'GET' })
+  const json = await res.json() as ExecResult
+
+  console.log('JAVARI_ROUTER exec', {
+    action:  params.action,
+    ok:      json.ok,
+    status:  res.status,
+  })
+
+  return json
+}
+
+// ── Billing intent dispatch ───────────────────────────────────────────────────
+// Maps a parsed billing intent + extracted params to an exec action.
+// Called by Javari AI when it identifies a billing-related request.
+
+export async function dispatchBillingIntent(
+  intent:  BillingIntent,
+  params:  Omit<ExecParams, 'action'>,
+  baseUrl?: string,
+): Promise<ExecResult> {
+  const actionMap: Record<BillingIntent, string> = {
+    grant_credits:  'grant_credits',
+    deduct_credits: 'credit_deduct',
+    get_balance:    'get_balance',
+    list_ledger:    'list_ledger',
+    get_user:       'get_user',
+    replay_webhook: 'replay_webhook',
+    health_check:   'health',
+  }
+
+  const action = actionMap[intent]
+  console.log('JAVARI_ROUTER dispatch_billing', { intent, action, userId: params.userId?.slice(0, 8) })
+  return callExec({ action, ...params }, baseUrl)
+}
+
+// ── Model tier selection for AI intents ───────────────────────────────────────
+// COST LAW: Free → Low (5x) → Moderate (4x) → Expensive (3x)
+// Never escalate without exhausting the lower tier first.
+
+export type ModelTier = 'gpt-4o-mini' | 'claude-haiku' | 'claude-sonnet'
+
+const AI_INTENT_TIERS: Record<AIIntent, ModelTier> = {
+  chat:  'gpt-4o-mini',
+  forge: 'gpt-4o-mini',
+  team:  'gpt-4o-mini',
+  image: 'gpt-4o-mini',
+  audio: 'gpt-4o-mini',
+  code:  'claude-haiku',   // code tasks benefit from Haiku's reasoning
+}
+
+export function selectModel(intent: AIIntent): ModelTier {
+  return AI_INTENT_TIERS[intent] ?? 'gpt-4o-mini'
+}
+
+// ── Main router ───────────────────────────────────────────────────────────────
+// Entry point for all Javari requests. Returns either:
+//   { type: 'billing', result: ExecResult }  — billing op executed server-side
+//   { type: 'ai', model: ModelTier }          — AI model selected for generation
+
+export async function route(
+  input:    string,
+  context?: { userId?: string; baseUrl?: string },
+): Promise<
+  | { type: 'billing'; intent: BillingIntent; result: ExecResult }
+  | { type: 'ai'; intent: AIIntent | 'unknown'; model: ModelTier }
+> {
+  const intent = classifyIntent(input)
+
+  // Billing intent — execute immediately via internal exec layer
+  if (intent !== 'unknown' && intent in BILLING_KEYWORDS) {
+    const billingIntent = intent as BillingIntent
+    const result = await dispatchBillingIntent(
+      billingIntent,
+      { userId: context?.userId, note: `javari_router: ${input.slice(0, 60)}` },
+      context?.baseUrl,
+    )
+    return { type: 'billing', intent: billingIntent, result }
+  }
+
+  // AI intent — select model tier
+  const aiIntent = intent as AIIntent | 'unknown'
+  const model    = selectModel(aiIntent === 'unknown' ? 'chat' : aiIntent)
+  console.log('JAVARI_ROUTER ai_dispatch', { intent: aiIntent, model })
+  return { type: 'ai', intent: aiIntent, model }
+}


### PR DESCRIPTION
## Files changed (6)

### Billing routes — observability
- `app/api/billing/usage/route.ts` — CANONICAL ROLE header, `logDirectAccess()` on GET+POST
- `app/api/billing/webhook/route.ts` — CANONICAL ROLE header + no-block warning, `DIRECT BILLING ROUTE ACCESS` log on POST
- `app/api/admin/payments/route.ts` — CANONICAL ROLE header, `logDirectAccess()` on GET
- `app/api/admin/credits/route.ts` — CANONICAL ROLE header, `logDirectAccess()` on GET
- `app/api/admin/webhooks/route.ts` — CANONICAL ROLE header, `logDirectAccess()` on GET

### New file
- `lib/javari/router.ts` — Javari billing+AI intent router. `classifyIntent()`, `callExec()`, `dispatchBillingIntent()`, `selectModel()`, `route()`. All billing intents route to `/api/internal/exec` via `INTERNAL_API_SECRET`.

### Feature flag
`BILLING_EXEC_MODE=internal_only` in Vercel env activates enhanced logging. No route is blocked — flag is observability-only.

Roy approved.