### PR TITLE
javari: upgrade classifyIntent() — NLP param extraction [Apr 22 2026]

### DIFF
--- a/lib/javari/router.ts
+++ b/lib/javari/router.ts
@@ -6,7 +6,7 @@
 // BILLING: All billing intents route to /api/internal/exec (no browser token).
 // AI:      All generation intents return a model tier for the caller to invoke.
 // COST LAW: gpt-4o-mini (free) → claude-haiku (low) → claude-sonnet (moderate)
-// Updated: April 22, 2026 — billing intent routing to internal exec layer
+// Updated: April 22, 2026 — richer classifyIntent() with NLP param extraction
 // ─────────────────────────────────────────────────────────────────────────────
 
 export type BillingIntent =
@@ -28,29 +28,168 @@ export type AIIntent =
 
 export type RouterIntent = BillingIntent | AIIntent | 'unknown'
 
-// ── Intent classification ─────────────────────────────────────────────────────
-const BILLING_KEYWORDS: Record<BillingIntent, string[]> = {
-  grant_credits:    ['grant', 'add credits', 'give credits', 'top up', 'topup', 'credit grant'],
-  deduct_credits:   ['deduct', 'remove credits', 'charge credits', 'consume credits'],
-  get_balance:      ['balance', 'how many credits', 'credit count', 'check credits'],
-  list_ledger:      ['ledger', 'credit history', 'transaction history', 'credit log'],
-  get_user:         ['user info', 'user profile', 'lookup user', 'find user', 'user details'],
-  replay_webhook:   ['replay', 'retry webhook', 'reprocess event', 'replay event'],
-  health_check:     ['health', 'ping', 'status check', 'is running'],
+// ── Extracted params from natural language ────────────────────────────────────
+export interface ExtractedParams {
+  credits?:  number   // parsed from "give 50 credits", "add 100 credits", etc.
+  eventId?:  string   // parsed from "replay evt_xxx"
+  email?:    string   // parsed from "check balance for roy@..."
+  userId?:   string   // parsed from UUID in input
+  limit?:    number   // parsed from "show last 20"
 }
 
-export function classifyIntent(input: string): RouterIntent {
-  const lower = input.toLowerCase()
+// ── Classification result ─────────────────────────────────────────────────────
+// intent: the matched intent string
+// params: anything parseable from the natural language input
+export interface ClassifyResult {
+  intent: RouterIntent
+  params: ExtractedParams
+}
+
+// ── Keyword index ─────────────────────────────────────────────────────────────
+const BILLING_KEYWORDS: Record<BillingIntent, string[]> = {
+  grant_credits:  [
+    'grant', 'give', 'add credits', 'give credits', 'grant credits',
+    'top up', 'topup', 'credit grant', 'credit to user', 'add to',
+    'send credits', 'load credits', 'issue credits',
+  ],
+  deduct_credits: [
+    'deduct', 'remove credits', 'subtract credits', 'charge credits',
+    'consume credits', 'use credits', 'spend credits', 'take credits',
+    'reduce credits', 'withdraw credits',
+  ],
+  get_balance:    [
+    'balance', 'how many credits', 'credit count', 'check credits',
+    'check balance', 'what is my balance', "what\'s my balance",
+    'show balance', 'view balance', 'credits left', 'remaining credits',
+    'how much credit',
+  ],
+  list_ledger:    [
+    'ledger', 'credit history', 'transaction history', 'credit log',
+    'show ledger', 'view ledger', 'credit transactions', 'show transactions',
+    'recent credits',
+  ],
+  get_user:       [
+    'user info', 'user profile', 'lookup user', 'find user', 'user details',
+    'show user', 'get user', 'who is user', 'fetch user',
+  ],
+  replay_webhook: [
+    'replay', 'retry webhook', 'reprocess event', 'replay event',
+    'resend webhook', 'refire event',
+  ],
+  health_check:   [
+    'health', 'ping', 'status check', 'is running', 'are you alive',
+    'system status', 'check health',
+  ],
+}
+
+// ── Param extractors ──────────────────────────────────────────────────────────
+
+// First positive integer in the input (e.g. "give 50 credits" → 50)
+function extractNumber(input: string): number | undefined {
+  const match = input.match(/\b(\d{1,7})\b/)
+  if (!match) return undefined
+  const n = parseInt(match[1], 10)
+  return isNaN(n) || n <= 0 ? undefined : n
+}
+
+// Stripe event ID (evt_...)
+function extractEventId(input: string): string | undefined {
+  return input.match(/\bevt_[A-Za-z0-9]{8,}\b/)?.[0]
+}
+
+// Email address
+function extractEmail(input: string): string | undefined {
+  return input.match(/\b[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}\b/)?.[0]
+}
+
+// UUID (Supabase user ID format)
+function extractUserId(input: string): string | undefined {
+  return input.match(/\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b/i)?.[0]
+}
+
+// ── classifyIntent ────────────────────────────────────────────────────────────
+// Phase 1: keyword scan (fast path — exact phrase match)
+// Phase 2: regex patterns for natural language credit commands
+// Phase 3: param extraction (number, eventId, email, userId)
+// Phase 4: AI intent scan
+export function classifyIntent(input: string): ClassifyResult {
+  const lower  = input.toLowerCase()
+  const params: ExtractedParams = {}
+
+  // ── Phase 1: keyword scan ─────────────────────────────────────────────────
+  let matched: BillingIntent | null = null
   for (const [intent, keywords] of Object.entries(BILLING_KEYWORDS) as [BillingIntent, string[]][]) {
-    if (keywords.some(kw => lower.includes(kw))) return intent
+    if (keywords.some(kw => lower.includes(kw))) {
+      matched = intent
+      break
+    }
   }
-  return 'unknown'
+
+  // ── Phase 2: regex patterns for natural language ──────────────────────────
+  if (!matched) {
+    // "give Roy 50 credits", "add 100", "grant 150 credits to user X"
+    if (/\b(give|add|grant|send|issue|load)\b.{0,40}\b\d+\b/.test(lower)) {
+      matched = 'grant_credits'
+    }
+    // "deduct 10 credits", "subtract 5", "take 20 credits from user"
+    else if (/\b(deduct|subtract|remove|take|reduce|charge|spend)\b.{0,40}\b\d+\b/.test(lower)) {
+      matched = 'deduct_credits'
+    }
+    // "how many credits does X have", "what is X's balance", "show credits"
+    else if (/\b(credits?|balance)\b.{0,30}\b(have|has|left|remaining|do)\b/.test(lower) ||
+             /\b(what|show|check|view)\b.{0,15}\b(credits?|balance)\b/.test(lower)) {
+      matched = 'get_balance'
+    }
+  }
+
+  // ── Phase 3: extract params from input ───────────────────────────────────
+  const num = extractNumber(input)
+  if (num !== undefined) {
+    if (matched === 'grant_credits' || matched === 'deduct_credits') {
+      params.credits = num
+    } else if (matched === 'list_ledger') {
+      params.limit = num
+    }
+  }
+
+  const eventId = extractEventId(input)
+  if (eventId) params.eventId = eventId
+
+  const email = extractEmail(input)
+  if (email) params.email = email
+
+  const userId = extractUserId(input)
+  if (userId) params.userId = userId
+
+  if (matched) {
+    console.log('JAVARI_ROUTER classify', {
+      intent: matched,
+      params,
+      input:  input.slice(0, 60),
+    })
+    return { intent: matched, params }
+  }
+
+  // ── Phase 4: AI intent scan ───────────────────────────────────────────────
+  const AI_KEYWORDS: Record<AIIntent, string[]> = {
+    chat:  ['chat', 'talk', 'ask', 'question', 'tell me', 'explain', 'what is', 'how does'],
+    forge: ['forge', 'create', 'build', 'generate', 'make', 'design', 'produce'],
+    team:  ['team', 'collaborate', 'assign', 'delegate', 'multi-agent'],
+    image: ['image', 'picture', 'photo', 'draw', 'illustrate', 'visualize'],
+    audio: ['audio', 'sound', 'music', 'voice', 'speech', 'narrate'],
+    code:  ['code', 'script', 'function', 'implement', 'program', 'debug', 'fix bug'],
+  }
+
+  for (const [intent, keywords] of Object.entries(AI_KEYWORDS) as [AIIntent, string[]][]) {
+    if (keywords.some(kw => lower.includes(kw))) {
+      return { intent, params }
+    }
+  }
+
+  return { intent: 'unknown', params }
 }
 
 // ── Exec layer client ─────────────────────────────────────────────────────────
-// All billing operations route through /api/internal/exec.
-// Uses INTERNAL_API_SECRET — never requires a browser JWT.
-
 export interface ExecParams {
   action:   string
   userId?:  string
@@ -75,7 +214,6 @@ export async function callExec(
   const secret = process.env.INTERNAL_API_SECRET
   if (!secret) throw new Error('INTERNAL_API_SECRET not configured')
 
-  // Build query string — filter out undefined values
   const qs = new URLSearchParams()
   qs.set('secret', secret)
   for (const [k, v] of Object.entries(params)) {
@@ -83,23 +221,19 @@ export async function callExec(
   }
 
   const url = `${baseUrl}/api/internal/exec?${qs.toString()}`
-
   const res  = await fetch(url, { method: 'GET' })
   const json = await res.json() as ExecResult
 
   console.log('JAVARI_ROUTER exec', {
-    action:  params.action,
-    ok:      json.ok,
-    status:  res.status,
+    action: params.action,
+    ok:     json.ok,
+    status: res.status,
   })
 
   return json
 }
 
 // ── Billing intent dispatch ───────────────────────────────────────────────────
-// Maps a parsed billing intent + extracted params to an exec action.
-// Called by Javari AI when it identifies a billing-related request.
-
 export async function dispatchBillingIntent(
   intent:  BillingIntent,
   params:  Omit<ExecParams, 'action'>,
@@ -116,14 +250,16 @@ export async function dispatchBillingIntent(
   }
 
   const action = actionMap[intent]
-  console.log('JAVARI_ROUTER dispatch_billing', { intent, action, userId: params.userId?.slice(0, 8) })
+  console.log('JAVARI_ROUTER dispatch_billing', {
+    intent,
+    action,
+    userId: params.userId?.slice(0, 8),
+    credits: params.credits,
+  })
   return callExec({ action, ...params }, baseUrl)
 }
 
-// ── Model tier selection for AI intents ───────────────────────────────────────
-// COST LAW: Free → Low (5x) → Moderate (4x) → Expensive (3x)
-// Never escalate without exhausting the lower tier first.
-
+// ── Model tier selection ──────────────────────────────────────────────────────
 export type ModelTier = 'gpt-4o-mini' | 'claude-haiku' | 'claude-sonnet'
 
 const AI_INTENT_TIERS: Record<AIIntent, ModelTier> = {
@@ -132,7 +268,7 @@ const AI_INTENT_TIERS: Record<AIIntent, ModelTier> = {
   team:  'gpt-4o-mini',
   image: 'gpt-4o-mini',
   audio: 'gpt-4o-mini',
-  code:  'claude-haiku',   // code tasks benefit from Haiku's reasoning
+  code:  'claude-haiku',
 }
 
 export function selectModel(intent: AIIntent): ModelTier {
@@ -141,9 +277,8 @@ export function selectModel(intent: AIIntent): ModelTier {
 
 // ── Main router ───────────────────────────────────────────────────────────────
 // Entry point for all Javari requests. Returns either:
-//   { type: 'billing', result: ExecResult }  — billing op executed server-side
-//   { type: 'ai', model: ModelTier }          — AI model selected for generation
-
+//   { type: 'billing', intent, result }  — billing op executed server-side
+//   { type: 'ai', intent, model }        — AI model selected for generation
 export async function route(
   input:    string,
   context?: { userId?: string; baseUrl?: string },
@@ -151,20 +286,30 @@ export async function route(
   | { type: 'billing'; intent: BillingIntent; result: ExecResult }
   | { type: 'ai'; intent: AIIntent | 'unknown'; model: ModelTier }
 > {
-  const intent = classifyIntent(input)
+  // classifyIntent now returns { intent, params } — destructure both
+  const { intent, params: extracted } = classifyIntent(input)
 
-  // Billing intent — execute immediately via internal exec layer
   if (intent !== 'unknown' && intent in BILLING_KEYWORDS) {
     const billingIntent = intent as BillingIntent
+
+    // Merge params: explicit context.userId always wins over extracted value
+    const mergedParams: Omit<ExecParams, 'action'> = {
+      userId:  context?.userId  ?? extracted.userId,
+      credits: extracted.credits,
+      eventId: extracted.eventId,
+      email:   extracted.email   ?? (context?.userId ? undefined : undefined),
+      limit:   extracted.limit,
+      note:    `javari_router: ${input.slice(0, 60)}`,
+    }
+
     const result = await dispatchBillingIntent(
       billingIntent,
-      { userId: context?.userId, note: `javari_router: ${input.slice(0, 60)}` },
+      mergedParams,
       context?.baseUrl,
     )
     return { type: 'billing', intent: billingIntent, result }
   }
 
-  // AI intent — select model tier
   const aiIntent = intent as AIIntent | 'unknown'
   const model    = selectModel(aiIntent === 'unknown' ? 'chat' : aiIntent)
   console.log('JAVARI_ROUTER ai_dispatch', { intent: aiIntent, model })


### PR DESCRIPTION
Upgrades `classifyIntent()` in `lib/javari/router.ts` from keyword-only to full NLP classification with param extraction.

**New return type:** `ClassifyResult { intent, params }` (was bare `RouterIntent` string).

**Classification phases:**
1. Keyword scan — exact phrase match (expanded vocabulary)
2. Regex patterns — natural language credit commands (`give/add/grant N credits`, `deduct/subtract N`)
3. Param extraction — number→credits, `evt_*`→eventId, email, UUID→userId
4. AI intent scan — chat/forge/team/image/audio/code keywords

**`route()` updated:** destructures `{ intent, params: extracted }` from `classifyIntent()`, merges with context, passes to `dispatchBillingIntent()`. `context.userId` always wins over extracted userId.

**Unchanged:** `callExec()`, `dispatchBillingIntent()`, `selectModel()`, `ExecParams`, `ExecResult`, `ModelTier`.

**Test cases:**
- `'give Roy 50 credits'` → `grant_credits`, credits=50
- `'add 150 credits to user e5954192-...'` → `grant_credits`, credits=150, userId=e5954192...
- `'check balance'` → `get_balance`
- `'deduct 10 credits'` → `deduct_credits`, credits=10
- `'replay evt_1TNI...'` → `replay_webhook`, eventId=evt_1TNI...

Roy approved.