### PR TITLE
javari: ExecutionMode auto|team + calculateCost + MultiAIPlan [Apr 22 2026]

### DIFF
--- a/lib/javari/router.ts
+++ b/lib/javari/router.ts
@@ -4,11 +4,91 @@
 // DO NOT CALL DIRECTLY from client components — import and use route() or
 //   dispatchBillingIntent() from server-side context only.
 // BILLING: All billing intents route to /api/internal/exec (no browser token).
-// AI:      All generation intents return a model tier for the caller to invoke.
+// AI auto: cheapest viable model via COST LAW.
+// AI team: returns multi-AI plan for user approval — does NOT execute.
 // COST LAW: gpt-4o-mini (free) → claude-haiku (low) → claude-sonnet (moderate)
-// Updated: April 22, 2026 — richer classifyIntent() with NLP param extraction
+// Updated: April 22, 2026 — ExecutionMode: auto | team
 // ─────────────────────────────────────────────────────────────────────────────
 
+// ── Execution mode ────────────────────────────────────────────────────────────
+// 'auto'  — default. classifyIntent + selectModel. Executes immediately.
+// 'team'  — user-configured Multi-AI team. Returns plan + cost. Requires approval.
+export type ExecutionMode = 'auto' | 'team'
+
+// ── Team configuration ────────────────────────────────────────────────────────
+// User assigns providers to roles. Any role can be omitted — unfilled roles are skipped.
+export interface TeamConfig {
+  architect?:  TeamProvider   // High-level planning, decomposition
+  builder?:    TeamProvider   // Implementation, code generation
+  tester?:     TeamProvider   // Validation, QA, adversarial testing
+  reviewer?:   TeamProvider   // Final review, quality gate
+  specialist?: TeamProvider   // Domain-specific (legal, medical, finance, etc.)
+}
+
+export type TeamProvider =
+  | 'openai'         // gpt-4o-mini (cheapest tier)
+  | 'openai-gpt4'    // gpt-4o (moderate)
+  | 'claude'         // claude-haiku (low)
+  | 'claude-sonnet'  // claude-sonnet-4 (moderate)
+  | 'xai'            // Grok (low-moderate)
+  | 'gemini'         // Gemini Flash (free tier)
+  | 'llama'          // Llama via Groq (free)
+
+// ── Provider cost table (relative units) ─────────────────────────────────────
+// Calibrated to COST LAW: free=0, low=1, moderate=2, high=5.
+// Update base/tier here when real API pricing is available.
+const PROVIDER_COST: Record<TeamProvider, { tier: 'free' | 'low' | 'moderate' | 'high'; base: number }> = {
+  'openai':        { tier: 'low',      base: 1 },
+  'openai-gpt4':   { tier: 'moderate', base: 2 },
+  'claude':        { tier: 'low',      base: 1 },
+  'claude-sonnet': { tier: 'moderate', base: 2 },
+  'xai':           { tier: 'low',      base: 1 },
+  'gemini':        { tier: 'free',     base: 0 },
+  'llama':         { tier: 'free',     base: 0 },
+}
+
+const TIER_MULTIPLIER: Record<'free' | 'low' | 'moderate' | 'high', number> = {
+  free:     0,
+  low:      1,
+  moderate: 2,
+  high:     5,
+}
+
+// ── Multi-AI plan result ──────────────────────────────────────────────────────
+// Returned by route() when mode === 'team'. Never executes. Requires approval.
+export interface MultiAIPlan {
+  type:              'multi_ai_plan'
+  roles:             TeamConfig
+  role_count:        number
+  providers:         Partial<Record<keyof TeamConfig, { provider: TeamProvider; tier: string; cost: number }>>
+  estimated_cost:    number
+  cost_breakdown:    string
+  requires_approval: true
+}
+
+// ── calculateCost ─────────────────────────────────────────────────────────────
+// Returns total relative cost + per-role breakdown for a TeamConfig.
+// cost = SUM of (base * TIER_MULTIPLIER) for each filled role.
+export function calculateCost(teamConfig: TeamConfig): {
+  total:     number
+  breakdown: Partial<Record<keyof TeamConfig, number>>
+} {
+  const breakdown: Partial<Record<keyof TeamConfig, number>> = {}
+  let total = 0
+
+  for (const [role, provider] of Object.entries(teamConfig) as [keyof TeamConfig, TeamProvider | undefined][]) {
+    if (!provider) continue
+    const entry = PROVIDER_COST[provider]
+    if (!entry) continue
+    const cost = entry.base * TIER_MULTIPLIER[entry.tier]
+    breakdown[role] = cost
+    total += cost
+  }
+
+  return { total, breakdown }
+}
+
+// ── Intent types ──────────────────────────────────────────────────────────────
 export type BillingIntent =
   | 'grant_credits'
   | 'deduct_credits'
@@ -38,8 +118,6 @@ export interface ExtractedParams {
 }
 
 // ── Classification result ─────────────────────────────────────────────────────
-// intent: the matched intent string
-// params: anything parseable from the natural language input
 export interface ClassifyResult {
   intent: RouterIntent
   params: ExtractedParams
@@ -59,7 +137,7 @@ const BILLING_KEYWORDS: Record<BillingIntent, string[]> = {
   ],
   get_balance:    [
     'balance', 'how many credits', 'credit count', 'check credits',
-    'check balance', 'what is my balance', "what\'s my balance",
+    'check balance', 'what is my balance', "what's my balance",
     'show balance', 'view balance', 'credits left', 'remaining credits',
     'how much credit',
   ],
@@ -84,7 +162,6 @@ const BILLING_KEYWORDS: Record<BillingIntent, string[]> = {
 
 // ── Param extractors ──────────────────────────────────────────────────────────
 
-// First positive integer in the input (e.g. "give 50 credits" → 50)
 function extractNumber(input: string): number | undefined {
   const match = input.match(/\b(\d{1,7})\b/)
   if (!match) return undefined
@@ -92,85 +169,61 @@ function extractNumber(input: string): number | undefined {
   return isNaN(n) || n <= 0 ? undefined : n
 }
 
-// Stripe event ID (evt_...)
 function extractEventId(input: string): string | undefined {
   return input.match(/\bevt_[A-Za-z0-9]{8,}\b/)?.[0]
 }
 
-// Email address
 function extractEmail(input: string): string | undefined {
   return input.match(/\b[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}\b/)?.[0]
 }
 
-// UUID (Supabase user ID format)
 function extractUserId(input: string): string | undefined {
   return input.match(/\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b/i)?.[0]
 }
 
 // ── classifyIntent ────────────────────────────────────────────────────────────
-// Phase 1: keyword scan (fast path — exact phrase match)
-// Phase 2: regex patterns for natural language credit commands
-// Phase 3: param extraction (number, eventId, email, userId)
-// Phase 4: AI intent scan
+// Phase 1: keyword scan  Phase 2: regex NLP  Phase 3: param extraction
+// Phase 4: AI keyword scan
 export function classifyIntent(input: string): ClassifyResult {
   const lower  = input.toLowerCase()
   const params: ExtractedParams = {}
 
-  // ── Phase 1: keyword scan ─────────────────────────────────────────────────
+  // Phase 1: keyword scan
   let matched: BillingIntent | null = null
   for (const [intent, keywords] of Object.entries(BILLING_KEYWORDS) as [BillingIntent, string[]][]) {
-    if (keywords.some(kw => lower.includes(kw))) {
-      matched = intent
-      break
-    }
+    if (keywords.some(kw => lower.includes(kw))) { matched = intent; break }
   }
 
-  // ── Phase 2: regex patterns for natural language ──────────────────────────
+  // Phase 2: regex NLP patterns
   if (!matched) {
-    // "give Roy 50 credits", "add 100", "grant 150 credits to user X"
     if (/\b(give|add|grant|send|issue|load)\b.{0,40}\b\d+\b/.test(lower)) {
       matched = 'grant_credits'
-    }
-    // "deduct 10 credits", "subtract 5", "take 20 credits from user"
-    else if (/\b(deduct|subtract|remove|take|reduce|charge|spend)\b.{0,40}\b\d+\b/.test(lower)) {
+    } else if (/\b(deduct|subtract|remove|take|reduce|charge|spend)\b.{0,40}\b\d+\b/.test(lower)) {
       matched = 'deduct_credits'
-    }
-    // "how many credits does X have", "what is X's balance", "show credits"
-    else if (/\b(credits?|balance)\b.{0,30}\b(have|has|left|remaining|do)\b/.test(lower) ||
-             /\b(what|show|check|view)\b.{0,15}\b(credits?|balance)\b/.test(lower)) {
+    } else if (
+      /\b(credits?|balance)\b.{0,30}\b(have|has|left|remaining|do)\b/.test(lower) ||
+      /\b(what|show|check|view)\b.{0,15}\b(credits?|balance)\b/.test(lower)
+    ) {
       matched = 'get_balance'
     }
   }
 
-  // ── Phase 3: extract params from input ───────────────────────────────────
+  // Phase 3: param extraction
   const num = extractNumber(input)
   if (num !== undefined) {
-    if (matched === 'grant_credits' || matched === 'deduct_credits') {
-      params.credits = num
-    } else if (matched === 'list_ledger') {
-      params.limit = num
-    }
+    if (matched === 'grant_credits' || matched === 'deduct_credits') params.credits = num
+    else if (matched === 'list_ledger') params.limit = num
   }
-
-  const eventId = extractEventId(input)
-  if (eventId) params.eventId = eventId
-
-  const email = extractEmail(input)
-  if (email) params.email = email
-
-  const userId = extractUserId(input)
-  if (userId) params.userId = userId
+  const eventId = extractEventId(input); if (eventId) params.eventId = eventId
+  const email   = extractEmail(input);   if (email)   params.email   = email
+  const userId  = extractUserId(input);  if (userId)  params.userId  = userId
 
   if (matched) {
-    console.log('JAVARI_ROUTER classify', {
-      intent: matched,
-      params,
-      input:  input.slice(0, 60),
-    })
+    console.log('JAVARI_ROUTER classify', { intent: matched, params, input: input.slice(0, 60) })
     return { intent: matched, params }
   }
 
-  // ── Phase 4: AI intent scan ───────────────────────────────────────────────
+  // Phase 4: AI intent scan
   const AI_KEYWORDS: Record<AIIntent, string[]> = {
     chat:  ['chat', 'talk', 'ask', 'question', 'tell me', 'explain', 'what is', 'how does'],
     forge: ['forge', 'create', 'build', 'generate', 'make', 'design', 'produce'],
@@ -179,11 +232,8 @@ export function classifyIntent(input: string): ClassifyResult {
     audio: ['audio', 'sound', 'music', 'voice', 'speech', 'narrate'],
     code:  ['code', 'script', 'function', 'implement', 'program', 'debug', 'fix bug'],
   }
-
   for (const [intent, keywords] of Object.entries(AI_KEYWORDS) as [AIIntent, string[]][]) {
-    if (keywords.some(kw => lower.includes(kw))) {
-      return { intent, params }
-    }
+    if (keywords.some(kw => lower.includes(kw))) return { intent, params }
   }
 
   return { intent: 'unknown', params }
@@ -224,12 +274,7 @@ export async function callExec(
   const res  = await fetch(url, { method: 'GET' })
   const json = await res.json() as ExecResult
 
-  console.log('JAVARI_ROUTER exec', {
-    action: params.action,
-    ok:     json.ok,
-    status: res.status,
-  })
-
+  console.log('JAVARI_ROUTER exec', { action: params.action, ok: json.ok, status: res.status })
   return json
 }
 
@@ -248,12 +293,10 @@ export async function dispatchBillingIntent(
     replay_webhook: 'replay_webhook',
     health_check:   'health',
   }
-
   const action = actionMap[intent]
   console.log('JAVARI_ROUTER dispatch_billing', {
-    intent,
-    action,
-    userId: params.userId?.slice(0, 8),
+    intent, action,
+    userId:  params.userId?.slice(0, 8),
     credits: params.credits,
   })
   return callExec({ action, ...params }, baseUrl)
@@ -275,43 +318,133 @@ export function selectModel(intent: AIIntent): ModelTier {
   return AI_INTENT_TIERS[intent] ?? 'gpt-4o-mini'
 }
 
-// ── Main router ───────────────────────────────────────────────────────────────
-// Entry point for all Javari requests. Returns either:
-//   { type: 'billing', intent, result }  — billing op executed server-side
-//   { type: 'ai', intent, model }        — AI model selected for generation
+// ── Route context ─────────────────────────────────────────────────────────────
+export interface RouteContext {
+  userId?:     string
+  baseUrl?:    string
+  teamConfig?: TeamConfig   // required when mode === 'team'
+}
+
+// ── Route result union ────────────────────────────────────────────────────────
+export type RouteResult =
+  | {
+      type:          'billing'
+      intent:        BillingIntent
+      result:        ExecResult
+      mode:          'auto'
+      cost_estimate: 'zero'
+    }
+  | {
+      type:          'ai'
+      intent:        AIIntent | 'unknown'
+      model:         ModelTier
+      mode:          'auto'
+      cost_estimate: 'low' | 'moderate'
+      executed:      false
+    }
+  | {
+      type:   'multi_ai_plan'
+      intent: AIIntent | 'unknown'
+      plan:   MultiAIPlan
+      mode:   'team'
+    }
+
+// ── route() ───────────────────────────────────────────────────────────────────
+// Entry point for all Javari requests.
+//
+// mode = 'auto' (default — backward compatible):
+//   Billing intent → executes immediately via /api/internal/exec
+//   AI intent      → returns cheapest viable model, does not execute
+//
+// mode = 'team':
+//   Requires context.teamConfig
+//   Does NOT execute — returns MultiAIPlan { requires_approval: true }
+//   Caller must display plan + get explicit user approval before firing agents
+//
+// All existing callers omitting mode default to 'auto' — zero breaking changes.
 export async function route(
-  input:    string,
-  context?: { userId?: string; baseUrl?: string },
-): Promise<
-  | { type: 'billing'; intent: BillingIntent; result: ExecResult }
-  | { type: 'ai'; intent: AIIntent | 'unknown'; model: ModelTier }
-> {
-  // classifyIntent now returns { intent, params } — destructure both
+  input:   string,
+  context?: RouteContext,
+  mode:     ExecutionMode = 'auto',
+): Promise<RouteResult> {
+
   const { intent, params: extracted } = classifyIntent(input)
 
+  console.log('JAVARI MODE', { mode, intent, input: input.slice(0, 60) })
+
+  // ── TEAM mode — build plan, do NOT execute ────────────────────────────────
+  if (mode === 'team') {
+    const teamConfig              = context?.teamConfig ?? {}
+    const { total, breakdown }    = calculateCost(teamConfig)
+    const roleCount               = Object.values(teamConfig).filter(Boolean).length
+
+    // Build per-role detail
+    const providers: MultiAIPlan['providers'] = {}
+    for (const [role, provider] of Object.entries(teamConfig) as [keyof TeamConfig, TeamProvider | undefined][]) {
+      if (!provider) continue
+      const entry = PROVIDER_COST[provider]
+      providers[role] = {
+        provider,
+        tier: entry?.tier ?? 'unknown',
+        cost: (entry?.base ?? 0) * TIER_MULTIPLIER[entry?.tier ?? 'free'],
+      }
+    }
+
+    // Human-readable breakdown string
+    const breakdownParts = Object.entries(breakdown).map(
+      ([role, cost]) => `${role}:${teamConfig[role as keyof TeamConfig]}(${cost}u)`
+    )
+    const costBreakdown = breakdownParts.length
+      ? breakdownParts.join(' + ') + ` = ${total}u`
+      : 'no roles configured — 0u'
+
+    const plan: MultiAIPlan = {
+      type:              'multi_ai_plan',
+      roles:             teamConfig,
+      role_count:        roleCount,
+      providers,
+      estimated_cost:    total,
+      cost_breakdown:    costBreakdown,
+      requires_approval: true,
+    }
+
+    console.log('JAVARI MODE team_plan', {
+      intent,
+      role_count:     roleCount,
+      estimated_cost: total,
+      breakdown:      costBreakdown,
+    })
+
+    return { type: 'multi_ai_plan', intent: intent as AIIntent | 'unknown', plan, mode: 'team' }
+  }
+
+  // ── AUTO mode — existing execution flow, unchanged ────────────────────────
   if (intent !== 'unknown' && intent in BILLING_KEYWORDS) {
     const billingIntent = intent as BillingIntent
-
-    // Merge params: explicit context.userId always wins over extracted value
     const mergedParams: Omit<ExecParams, 'action'> = {
-      userId:  context?.userId  ?? extracted.userId,
+      userId:  context?.userId ?? extracted.userId,
       credits: extracted.credits,
       eventId: extracted.eventId,
-      email:   extracted.email   ?? (context?.userId ? undefined : undefined),
+      email:   extracted.email,
       limit:   extracted.limit,
       note:    `javari_router: ${input.slice(0, 60)}`,
     }
-
-    const result = await dispatchBillingIntent(
-      billingIntent,
-      mergedParams,
-      context?.baseUrl,
-    )
-    return { type: 'billing', intent: billingIntent, result }
+    const result = await dispatchBillingIntent(billingIntent, mergedParams, context?.baseUrl)
+    return { type: 'billing', intent: billingIntent, result, mode: 'auto', cost_estimate: 'zero' }
   }
 
-  const aiIntent = intent as AIIntent | 'unknown'
-  const model    = selectModel(aiIntent === 'unknown' ? 'chat' : aiIntent)
-  console.log('JAVARI_ROUTER ai_dispatch', { intent: aiIntent, model })
-  return { type: 'ai', intent: aiIntent, model }
+  const aiIntent     = intent as AIIntent | 'unknown'
+  const model        = selectModel(aiIntent === 'unknown' ? 'chat' : aiIntent)
+  const costEstimate: 'low' | 'moderate' = model === 'claude-sonnet' ? 'moderate' : 'low'
+
+  console.log('JAVARI_ROUTER ai_dispatch', { intent: aiIntent, model, mode: 'auto' })
+
+  return {
+    type:          'ai',
+    intent:        aiIntent,
+    model,
+    mode:          'auto',
+    cost_estimate: costEstimate,
+    executed:      false,
+  }
 }


### PR DESCRIPTION
Adds two execution modes to `lib/javari/router.ts`.

## New exports
- `ExecutionMode = 'auto' | 'team'`
- `TeamConfig` — role → provider mapping (architect, builder, tester, reviewer, specialist)
- `TeamProvider` — 7 providers: openai, openai-gpt4, claude, claude-sonnet, xai, gemini, llama
- `MultiAIPlan` — plan object returned in team mode (`requires_approval: true`)
- `calculateCost(teamConfig)` — relative cost using PROVIDER_COST × TIER_MULTIPLIER
- `RouteContext` — extended with `teamConfig?`
- `RouteResult` — discriminated union of billing | ai | multi_ai_plan responses

## Updated `route()` signature
`route(input, context?, mode: ExecutionMode = 'auto')`

## Behaviour
- `mode='auto'` — identical to previous, zero breaking changes
- `mode='team'` — builds `MultiAIPlan`, logs cost breakdown, **never executes**

## Unchanged
`classifyIntent`, `callExec`, `dispatchBillingIntent`, `selectModel`, `BILLING_KEYWORDS`, all param extractors, `/api/internal/exec`.

Roy approved.