### PR TITLE
javari: execute — mode param + multi_ai_plan response [Apr 23 2026]

### DIFF
--- a/app/api/javari/execute/route.ts
+++ b/app/api/javari/execute/route.ts
@@ -2,18 +2,24 @@
 // ─────────────────────────────────────────────────────────────────────────────
 // Javari execution endpoint — wires lib/javari/router.ts into a live API call.
 // Accepts natural-language input, classifies intent, dispatches automatically:
-//   billing intent → executes via /api/internal/exec (no browser token needed)
-//   AI intent      → returns selected model + intent for caller to invoke
+//   billing intent    → executes via /api/internal/exec (no browser token)
+//   AI intent         → returns selected model + intent for caller to invoke
+//   multi_ai_plan     → returns team plan + cost for caller approval
 //
 // Auth: X-Internal-Secret header OR public (if JAVARI_EXECUTE_PUBLIC=true).
 //   Default: requires X-Internal-Secret — server-to-server only.
 //   To allow Javari frontend to call: set JAVARI_EXECUTE_PUBLIC=true in Vercel.
 //
-// POST { input, context? }
+// POST { input, context?, mode? }
 //   input:   natural language command (e.g. "check balance for user abc")
-//   context: { userId?, email?, credits?, eventId?, baseUrl? }
+//   mode:    'auto' (default) | 'team'
+//   context: {
+//     userId?,      — target user for billing ops
+//     teamConfig?,  — required when mode === 'team'
+//     baseUrl?
+//   }
 //
-// Updated: April 22, 2026
+// Updated: April 23, 2026 — mode param, teamConfig, multi_ai_plan response
 // ─────────────────────────────────────────────────────────────────────────────
 
 import { NextRequest, NextResponse } from 'next/server'
@@ -23,6 +29,10 @@ import {
   type AIIntent,
   type ExecResult,
   type ModelTier,
+  type TeamConfig,
+  type MultiAIPlan,
+  type ExecutionMode,
+  type RouteContext,
 } from '@/lib/javari/router'
 
 export const dynamic    = 'force-dynamic'
@@ -48,6 +58,7 @@ interface BillingResponse {
   executed:   boolean
   result:     ExecResult
   input_echo: string
+  mode:       'auto'
   ts:         string
 }
 
@@ -56,10 +67,22 @@ interface AIResponse {
   type:       'ai'
   intent:     AIIntent | 'unknown'
   model:      ModelTier
-  executed:   boolean     // always false — AI intents return model selection only
+  executed:   boolean   // always false — AI intents return model selection only
   message:    string
   input_echo: string
+  mode:       'auto'
   ts:         string
+}
+
+interface TeamPlanResponse {
+  ok:                boolean
+  type:              'team'
+  intent:            AIIntent | 'unknown'
+  plan:              MultiAIPlan
+  requires_approval: true
+  input_echo:        string
+  mode:              'team'
+  ts:                string
 }
 
 // ── POST /api/javari/execute ──────────────────────────────────────────────────
@@ -68,19 +91,16 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
 
-  let input: string
-  let context: {
-    userId?:  string
-    email?:   string
-    credits?: number
-    eventId?: string
-    limit?:   number
-    note?:    string
-    baseUrl?: string
-  } | undefined
+  let input:   string
+  let context: RouteContext | undefined
+  let mode:    ExecutionMode
 
   try {
-    const body = await req.json() as { input?: unknown; context?: unknown }
+    const body = await req.json() as {
+      input?:   unknown
+      context?: unknown
+      mode?:    unknown
+    }
 
     if (!body.input || typeof body.input !== 'string' || body.input.trim() === '') {
       return NextResponse.json(
@@ -89,21 +109,51 @@ export async function POST(req: NextRequest) {
       )
     }
 
-    input   = body.input.trim()
-    context = typeof body.context === 'object' && body.context !== null
-      ? body.context as typeof context
-      : undefined
+    // mode defaults to 'auto' — backward compatible with all existing callers
+    const rawMode = body.mode
+    if (rawMode !== undefined && rawMode !== 'auto' && rawMode !== 'team') {
+      return NextResponse.json(
+        { error: "mode must be 'auto' or 'team'" },
+        { status: 400 }
+      )
+    }
+    mode  = (rawMode as ExecutionMode) ?? 'auto'
+    input = body.input.trim()
+
+    // Build RouteContext — include teamConfig when present
+    if (typeof body.context === 'object' && body.context !== null) {
+      const raw = body.context as Record<string, unknown>
+      context = {
+        userId:     typeof raw.userId     === 'string' ? raw.userId     : undefined,
+        baseUrl:    typeof raw.baseUrl    === 'string' ? raw.baseUrl    : undefined,
+        teamConfig: typeof raw.teamConfig === 'object' && raw.teamConfig !== null
+          ? raw.teamConfig as TeamConfig
+          : undefined,
+      }
+    }
 
   } catch {
     return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 })
   }
 
+  // Guard: team mode requires teamConfig
+  if (mode === 'team' && !context?.teamConfig) {
+    return NextResponse.json(
+      { error: "mode 'team' requires context.teamConfig to be set" },
+      { status: 400 }
+    )
+  }
+
   const ts = new Date().toISOString()
 
   try {
-    const routeResult = await route(input, {
-      userId:  context?.userId,
-      baseUrl: context?.baseUrl,
+    const routeResult = await route(input, context, mode)
+
+    // Log every execution with mode + type + intent
+    console.log('JAVARI EXECUTE MODE', {
+      mode,
+      intent: routeResult.intent,
+      type:   routeResult.type,
     })
 
     // ── Billing intent — already executed by route() ──────────────────────────
@@ -115,6 +165,7 @@ export async function POST(req: NextRequest) {
         executed:   true,
         result:     routeResult.result,
         input_echo: input.slice(0, 120),
+        mode:       'auto',
         ts,
       }
 
@@ -124,6 +175,30 @@ export async function POST(req: NextRequest) {
         ok:     routeResult.result.ok,
         userId: context?.userId?.slice(0, 8),
         input:  input.slice(0, 60),
+      })
+
+      return NextResponse.json(response)
+    }
+
+    // ── Multi-AI team plan — return for approval, do NOT execute ─────────────
+    if (routeResult.type === 'multi_ai_plan') {
+      const response: TeamPlanResponse = {
+        ok:                true,
+        type:              'team',
+        intent:            routeResult.intent,
+        plan:              routeResult.plan,
+        requires_approval: true,
+        input_echo:        input.slice(0, 120),
+        mode:              'team',
+        ts,
+      }
+
+      console.log('JAVARI EXECUTE', {
+        type:           'team',
+        intent:         routeResult.intent,
+        role_count:     routeResult.plan.role_count,
+        estimated_cost: routeResult.plan.estimated_cost,
+        input:          input.slice(0, 60),
       })
 
       return NextResponse.json(response)
@@ -140,6 +215,7 @@ export async function POST(req: NextRequest) {
                   `Selected model: ${routeResult.model}. ` +
                   `Call /api/javari/chat with model=${routeResult.model} to execute.`,
       input_echo: input.slice(0, 120),
+      mode:       'auto',
       ts,
     }
 
@@ -155,6 +231,7 @@ export async function POST(req: NextRequest) {
   } catch (err: unknown) {
     const msg = err instanceof Error ? err.message : String(err)
     console.error('[javari/execute] error:', {
+      mode,
       input: input.slice(0, 60),
       error: msg,
     })


### PR DESCRIPTION
Extends `POST /api/javari/execute` to support execution modes.

**New body params:**
- `mode?: 'auto' | 'team'` — defaults to `'auto'` (backward compatible)
- `context.teamConfig?` — passed through to `route()` for team mode

**New response type:** `TeamPlanResponse` when `mode='team'`:
```json
{ ok, type: 'team', intent, plan, requires_approval: true, mode: 'team', ts }
```

**New log:** `JAVARI EXECUTE MODE { mode, intent, type }` — fires on every request.

**Guard:** `mode='team'` without `context.teamConfig` → HTTP 400.

**`route()` call** now passes all three args: `route(input, context, mode)`.

**Unchanged:** auth, billing branch, AI branch, `/api/internal/exec`, router logic.

Roy approved.